### PR TITLE
Shader-based texture AA

### DIFF
--- a/Quake/gl_shaders.c
+++ b/Quake/gl_shaders.c
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "gl_shaders.h"
 
 glprogs_t glprogs;
-static GLuint gl_programs[64];
+static GLuint gl_programs[128];
 static GLuint gl_current_program;
 static int gl_num_programs;
 
@@ -280,7 +280,7 @@ GL_CreateShaders
 */
 void GL_CreateShaders (void)
 {
-	int palettize, dither, mode, alphatest, warp;
+	int palettize, dither, mode, alphatest, warp, ss;
 
 	glprogs.gui = GL_CreateProgram (gui_vertex_shader, gui_fragment_shader, "gui");
 	glprogs.viewblend = GL_CreateProgram (viewblend_vertex_shader, viewblend_fragment_shader, "viewblend");
@@ -289,24 +289,26 @@ void GL_CreateShaders (void)
 	for (palettize = 0; palettize < 3; palettize++)
 		glprogs.postprocess[palettize] = GL_CreateProgram (postprocess_vertex_shader, postprocess_fragment_shader, "postprocess|PALETTIZE %d", palettize);
 
-	for (dither = 0; dither < 3; dither++)
+	for (ss = 0; ss < 2; ss++) {
 		for (mode = 0; mode < 3; mode++)
-			glprogs.world[dither][mode] = GL_CreateProgram (world_vertex_shader, world_fragment_shader, "world|DITHER %d; MODE %d", dither, mode);
+			for (dither = 0; dither < 3; dither++)
+				glprogs.world[ss][dither][mode] = GL_CreateProgram (world_vertex_shader, world_fragment_shader, "world|DITHER %d; MODE %d; SS %d", dither, mode, ss);
 
-	for (dither = 0; dither < 2; dither++)
-	{
-		glprogs.water[dither] = GL_CreateProgram (water_vertex_shader, water_fragment_shader, "water|DITHER %d", dither);
-		glprogs.skylayers[dither] = GL_CreateProgram (sky_layers_vertex_shader, sky_layers_fragment_shader, "sky layers|DITHER %d", dither);
-		glprogs.skycubemap[dither] = GL_CreateProgram (sky_cubemap_vertex_shader, sky_cubemap_fragment_shader, "sky cubemap|DITHER %d", dither);
-		glprogs.skyboxside[dither] = GL_CreateProgram (sky_boxside_vertex_shader, sky_boxside_fragment_shader, "skybox side|DITHER %d", dither);
-		glprogs.sprites[dither] = GL_CreateProgram (sprites_vertex_shader, sprites_fragment_shader, "sprites|DITHER %d", dither);
-		glprogs.particles[dither] = GL_CreateProgram (particles_vertex_shader, particles_fragment_shader, "particles|DITHER %d", dither);
+		for (dither = 0; dither < 2; dither++)
+		{
+			glprogs.water[ss][dither] = GL_CreateProgram(water_vertex_shader, water_fragment_shader, "water|DITHER %d; SS %d", dither == 1, ss);
+			glprogs.skylayers[ss][dither] = GL_CreateProgram(sky_layers_vertex_shader, sky_layers_fragment_shader, "sky layers|DITHER %d; SS %d", dither, ss);
+			glprogs.skycubemap[ss][dither] = GL_CreateProgram(sky_cubemap_vertex_shader, sky_cubemap_fragment_shader, "sky cubemap|DITHER %d; SS %d", dither, ss);
+			glprogs.skyboxside[ss][dither] = GL_CreateProgram(sky_boxside_vertex_shader, sky_boxside_fragment_shader, "skybox side|DITHER %d; SS %d", dither, ss);
+			glprogs.sprites[ss][dither] = GL_CreateProgram(sprites_vertex_shader, sprites_fragment_shader, "sprites|DITHER %d; SS %d", dither, ss);
+			glprogs.particles[ss][dither] = GL_CreateProgram(particles_vertex_shader, particles_fragment_shader, "particles|DITHER %d; SS %d", dither, ss);
+		}
+
+		for (mode = 0; mode < 3; mode++)
+			for (alphatest = 0; alphatest < 2; alphatest++)
+				glprogs.alias[ss][mode][alphatest] = GL_CreateProgram(alias_vertex_shader, alias_fragment_shader, "alias|MODE %d; ALPHATEST %d; SS %d", mode, alphatest, ss);
 	}
 	glprogs.skystencil = GL_CreateProgram (skystencil_vertex_shader, NULL, "sky stencil");
-
-	for (mode = 0; mode < 3; mode++)
-		for (alphatest = 0; alphatest < 2; alphatest++)
-			glprogs.alias[mode][alphatest] = GL_CreateProgram (alias_vertex_shader, alias_fragment_shader, "alias|MODE %d; ALPHATEST %d", mode, alphatest);
 
 	glprogs.debug3d = GL_CreateProgram (debug3d_vertex_shader, debug3d_fragment_shader, "debug3d");
 

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -37,6 +37,7 @@ static byte *skybox_cubemap_pixels;
 static void *skybox_cubemap_offsets[6];
 
 extern cvar_t gl_farclip;
+extern cvar_t gl_supersampletex;
 cvar_t r_fastsky = {"r_fastsky", "0", CVAR_NONE};
 cvar_t r_skyalpha = {"r_skyalpha", "1", CVAR_NONE};
 cvar_t r_skyfog = {"r_skyfog","0.5",CVAR_NONE};
@@ -478,7 +479,7 @@ void Sky_DrawSkyBox (void)
 	fog[2] = r_framedata.fogdata[2];
 	fog[3] = r_framedata.fogdata[3] > 0.f ? skyfog : 0.f;
 
-	GL_UseProgram (glprogs.skyboxside[softemu == SOFTEMU_COARSE]);
+	GL_UseProgram (glprogs.skyboxside[(gl_supersampletex.value != 0)][softemu == SOFTEMU_COARSE]);
 	GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZTEST | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));
 
 	GL_UniformMatrix4fvFunc (0, 1, GL_FALSE, r_matviewproj);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -38,6 +38,7 @@ static const struct {
 };
 
 static cvar_t	r_softemu = {"r_softemu", "0", CVAR_ARCHIVE};
+cvar_t			gl_supersampletex = {"gl_supersampletex", "0", CVAR_ARCHIVE};
 static cvar_t	gl_max_size = {"gl_max_size", "0", CVAR_NONE};
 static cvar_t	gl_picmip = {"gl_picmip", "0", CVAR_NONE};
 cvar_t			gl_texturemode = {"gl_texturemode", "", CVAR_ARCHIVE};
@@ -743,6 +744,7 @@ void TexMgr_Init (void)
 	Cvar_RegisterVariable (&gl_texturemode);
 	Cvar_SetCallback (&gl_texturemode, &TexMgr_TextureMode_f);
 	Cvar_RegisterVariable (&r_softemu);
+	Cvar_RegisterVariable (&gl_supersampletex);
 	Cvar_SetCallback (&r_softemu, TexMgr_SoftEmu_f);
 	Cmd_AddCommand ("gl_describetexturemodes", &TexMgr_DescribeTextureModes_f);
 	Cmd_AddCommand ("imagelist", &TexMgr_Imagelist_f);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1178,7 +1178,7 @@ static void GL_Init (void)
 	}
 	//johnfitz
 
-	GL_CreateShaders ();
+	GL_CreateShaders_Static ();
 	GL_CreateFrameBuffers ();
 	GLWorld_CreateResources ();
 	GLLight_CreateResources ();
@@ -1196,6 +1196,8 @@ GL_BeginRendering -- sets values of glx, gly, glwidth, glheight
 void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
 	qboolean postprocess = vid_gamma.value != 1.f || vid_contrast.value != 1.f || softemu;
+
+	GL_CreateShaders_Permutation (gl_supersampletex.value != 0, softemu);
 
 	*x = *y = 0;
 	*width = vid.width;

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -501,7 +501,8 @@ extern glprogs_t glprogs;
 
 void GL_UseProgram (GLuint program);
 void GL_ClearCachedProgram (void);
-void GL_CreateShaders (void);
+void GL_CreateShaders_Static (void);
+void GL_CreateShaders_Permutation (int ss, int any_dither);
 void GL_DeleteShaders (void);
 
 typedef struct glframebufs_s {

--- a/Quake/glquake.h
+++ b/Quake/glquake.h
@@ -477,15 +477,15 @@ typedef struct glprogs_s {
 	GLuint		postprocess[3];	// [palettize:off/dithered/direct]
 
 	/* 3d */
-	GLuint		world[3][3];	// [dither][mode:solid/alpha test/water]
-	GLuint		water[2];		// [dither]
+	GLuint		world[2][3][3];		// [supersample][dither][mode:solid/alpha test/water]
+	GLuint		water[2][2];		// [supersample][dither]
 	GLuint		skystencil;
-	GLuint		skylayers[2];	// [dither]
-	GLuint		skycubemap[2];	// [dither]
-	GLuint		skyboxside[2];	// [dither]
-	GLuint		alias[3][2];	// [mode:standard/dithered/noperspective][alpha test]
-	GLuint		sprites[2];		// [dither]
-	GLuint		particles[2];	// [dither]
+	GLuint		skylayers[2][2];	// [supersample][dither]
+	GLuint		skycubemap[2][2];	// [supersample][dither]
+	GLuint		skyboxside[2][2];	// [supersample][dither]
+	GLuint		alias[2][3][2];		// [supersample][mode:standard/dithered/noperspective][alpha test]
+	GLuint		sprites[2][2];		// [supersample][dither][dither]
+	GLuint		particles[2][2];	// [supersample][dither]
 	GLuint		debug3d;
 
 	/* compute */

--- a/Quake/r_alias.c
+++ b/Quake/r_alias.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern cvar_t gl_overbright_models, gl_fullbrights, r_lerpmodels, r_lerpmove; //johnfitz
 extern cvar_t scr_fov, cl_gun_fovscale;
+extern cvar_t gl_supersampletex;
 
 //up to 16 color translated skins
 gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz -- changed to an array of pointers
@@ -320,13 +321,13 @@ void R_FlushAliasInstances (void)
 	switch (softemu)
 	{
 	case SOFTEMU_BANDED:
-		program = glprogs.alias[ALIASSHADER_NOPERSP][alphatest];
+		program = glprogs.alias[(gl_supersampletex.value != 0)][ALIASSHADER_NOPERSP][alphatest];
 		break;
 	case SOFTEMU_COARSE:
-		program = glprogs.alias[ALIASSHADER_DITHER][alphatest];
+		program = glprogs.alias[(gl_supersampletex.value != 0)][ALIASSHADER_DITHER][alphatest];
 		break;
 	default:
-		program = glprogs.alias[ALIASSHADER_STANDARD][alphatest];
+		program = glprogs.alias[(gl_supersampletex.value != 0)][ALIASSHADER_STANDARD][alphatest];
 		break;
 	}
 	GL_UseProgram (program);

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -859,7 +859,7 @@ static void R_DrawParticles_Real (qboolean showtris)
 	GLubyte			color[4] = {255, 255, 255, 255}, *c; //johnfitz -- particle transparency
 	extern	cvar_t	r_particles; //johnfitz
 	//float			alpha; //johnfitz -- particle transparency
-	qboolean		dither;
+	qboolean		dither, ss;
 
 	if (!r_particles.value)
 		return;
@@ -870,7 +870,8 @@ static void R_DrawParticles_Real (qboolean showtris)
 	GL_BeginGroup ("Particles");
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.particles[(gl_supersampletex.value != 0)][dither]);
+	ss = (gl_supersampletex.value != 0 && !showtris);
+	GL_UseProgram (glprogs.particles[ss][dither]);
 	GL_Bind (GL_TEXTURE0, showtris ? whitetexture : particletexture);
 
 	GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));

--- a/Quake/r_part.c
+++ b/Quake/r_part.c
@@ -42,6 +42,7 @@ gltexture_t *particletexture, *particletexture1, *particletexture2, *particletex
 float texturescalefactor; //johnfitz -- compensate for apparent size of different particle textures
 
 cvar_t	r_particles = {"r_particles","2", CVAR_ARCHIVE}; //johnfitz
+extern cvar_t gl_supersampletex;
 
 typedef struct particlevert_t {
 	vec3_t		pos;
@@ -869,7 +870,7 @@ static void R_DrawParticles_Real (qboolean showtris)
 	GL_BeginGroup ("Particles");
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.particles[dither]);
+	GL_UseProgram (glprogs.particles[(gl_supersampletex.value != 0)][dither]);
 	GL_Bind (GL_TEXTURE0, showtris ? whitetexture : particletexture);
 
 	GL_SetState (GLS_BLEND_ALPHA | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -123,7 +123,7 @@ R_FlushSpriteInstances
 */
 static void R_FlushSpriteInstances (void)
 {
-	qboolean		dither;
+	qboolean		dither, ss;
 	qboolean		showtris = batchshowtris;
 	msprite_t		*psprite;
 	GLuint			buf;
@@ -142,7 +142,8 @@ static void R_FlushSpriteInstances (void)
 		GL_PolygonOffset (OFFSET_DECAL);
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.sprites[(gl_supersampletex.value != 0)][dither]);
+	ss = (gl_supersampletex.value != 0 && !showtris);
+	GL_UseProgram (glprogs.sprites[ss][dither]);
 
 	if (showtris)
 		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));

--- a/Quake/r_sprite.c
+++ b/Quake/r_sprite.c
@@ -39,6 +39,8 @@ static qboolean batchshowtris;
 static GLushort batchindices[6 * MAX_BATCH_SPRITES];
 static qboolean batchindices_init = false;
 
+extern cvar_t gl_supersampletex;
+
 /*
 ================
 R_InitSpriteIndices
@@ -140,7 +142,7 @@ static void R_FlushSpriteInstances (void)
 		GL_PolygonOffset (OFFSET_DECAL);
 
 	dither = (softemu == SOFTEMU_COARSE && !showtris);
-	GL_UseProgram (glprogs.sprites[dither]);
+	GL_UseProgram (glprogs.sprites[(gl_supersampletex.value != 0)][dither]);
 
 	if (showtris)
 		GL_SetState (GLS_BLEND_OPAQUE | GLS_NO_ZWRITE | GLS_CULL_NONE | GLS_ATTRIBS(2));

--- a/Quake/r_world.c
+++ b/Quake/r_world.c
@@ -26,6 +26,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 extern cvar_t gl_fullbrights, r_oldskyleaf, r_showtris; //johnfitz
 extern cvar_t gl_zfix; // QuakeSpasm z-fighting fix
+extern cvar_t gl_supersampletex;
 
 extern gltexture_t *lightmap_texture;
 extern gltexture_t *skybox_cubemap;
@@ -536,22 +537,22 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	case BP_SOLID:
 		texbegin = 0;
 		texend = TEXTYPE_CUTOUT;
-		program = glprogs.world[q_max(0, (int)softemu - 1)][WORLDSHADER_SOLID];
+		program = glprogs.world[(gl_supersampletex.value != 0)][q_max(0, (int)softemu - 1)][WORLDSHADER_SOLID];
 		break;
 	case BP_ALPHATEST:
 		texbegin = TEXTYPE_CUTOUT;
 		texend = TEXTYPE_CUTOUT + 1;
-		program = glprogs.world[q_max(0, (int)softemu - 1)][WORLDSHADER_ALPHATEST];
+		program = glprogs.world[(gl_supersampletex.value != 0)][q_max(0, (int)softemu - 1)][WORLDSHADER_ALPHATEST];
 		break;
 	case BP_SKYLAYERS:
 		texbegin = TEXTYPE_SKY;
 		texend = TEXTYPE_SKY + 1;
-		program = glprogs.skylayers[softemu == SOFTEMU_COARSE];
+		program = glprogs.skylayers[(gl_supersampletex.value != 0)][softemu == SOFTEMU_COARSE];
 		break;
 	case BP_SKYCUBEMAP:
 		texbegin = TEXTYPE_SKY;
 		texend = TEXTYPE_SKY + 1;
-		program = glprogs.skycubemap[softemu == SOFTEMU_COARSE];
+		program = glprogs.skycubemap[(gl_supersampletex.value != 0)][softemu == SOFTEMU_COARSE];
 		break;
 	case BP_SKYSTENCIL:
 		texbegin = TEXTYPE_SKY;
@@ -561,7 +562,7 @@ static void R_DrawBrushModels_Real (entity_t **ents, int count, brushpass_t pass
 	case BP_SHOWTRIS:
 		texbegin = 0;
 		texend = TEXTYPE_COUNT;
-		program = glprogs.world[0][0];
+		program = glprogs.world[0][0][0];
 		break;
 	}
 
@@ -672,9 +673,9 @@ void R_DrawBrushModels_Water (entity_t **ents, int count, qboolean translucent)
 		state |= GLS_BLEND_OPAQUE;
 
 	if (cl.worldmodel->haslitwater && r_litwater.value)
-		program = glprogs.world[q_max(0, (int)softemu - 1)][WORLDSHADER_WATER];
+		program = glprogs.world[(gl_supersampletex.value != 0)][q_max(0, (int)softemu - 1)][WORLDSHADER_WATER];
 	else
-		program = glprogs.water[softemu == SOFTEMU_COARSE];
+		program = glprogs.water[(gl_supersampletex.value != 0)][softemu == SOFTEMU_COARSE];
 
 	R_ResetBModelCalls (program);
 	GL_SetState (state);


### PR DESCRIPTION
This adds shader-based texture supersampling. This can be used for anti-aliased nearest neighborhood filtered textures:
![](https://user-images.githubusercontent.com/24851409/160221448-5f52db1a-fd98-4cec-8d0a-ea114f7c60c3.gif)

It also reduces shimmering:
unfiltered             |  supersampled
:-:|:-:
![](https://user-images.githubusercontent.com/24851409/160221245-be1925e6-c34c-4f7a-a056-f9b75ea79855.gif)  |  ![](https://user-images.githubusercontent.com/24851409/160221240-bff0587b-c8b6-47eb-8152-31e0a2263472.gif)

This is cheaper than per sample shading, and cheaper and higher quality than ordered grid supersampling.

Known limitations:
* cutout alpha textures are not supersampled (would look worse as implemented)
* possible color bleeds since there's no centroid sampling (I have not seen this happen)