### PR TITLE
Make byte-order function inlines when endianness is known at compile time

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -619,6 +619,7 @@ float Q_atof (const char *str)
 	return val*sign;
 }
 
+#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
 /*
 ============================================================================
 
@@ -689,6 +690,7 @@ float FloatNoSwap (float f)
 {
 	return f;
 }
+#endif
 
 /*
 ==============================================================================
@@ -1456,6 +1458,7 @@ COM_Init
 */
 void COM_Init (void)
 {
+#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
 	int	i = 0x12345678;
 		/*    U N I X */
 
@@ -1494,7 +1497,7 @@ void COM_Init (void)
 		BigFloat = FloatSwap;
 		LittleFloat = FloatNoSwap;
 	}
-
+#endif
 	if (COM_CheckParm("-fitz"))
 		fitzmode = true;
 }

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -619,78 +619,6 @@ float Q_atof (const char *str)
 	return val*sign;
 }
 
-#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
-/*
-============================================================================
-
-					BYTE ORDER FUNCTIONS
-
-============================================================================
-*/
-
-qboolean	host_bigendian;
-
-short	(*BigShort) (short l);
-short	(*LittleShort) (short l);
-int	(*BigLong) (int l);
-int	(*LittleLong) (int l);
-float	(*BigFloat) (float l);
-float	(*LittleFloat) (float l);
-
-short ShortSwap (short l)
-{
-	byte	b1, b2;
-
-	b1 = l&255;
-	b2 = (l>>8)&255;
-
-	return (b1<<8) + b2;
-}
-
-short ShortNoSwap (short l)
-{
-	return l;
-}
-
-int LongSwap (int l)
-{
-	byte	b1, b2, b3, b4;
-
-	b1 = l&255;
-	b2 = (l>>8)&255;
-	b3 = (l>>16)&255;
-	b4 = (l>>24)&255;
-
-	return ((int)b1<<24) + ((int)b2<<16) + ((int)b3<<8) + b4;
-}
-
-int LongNoSwap (int l)
-{
-	return l;
-}
-
-float FloatSwap (float f)
-{
-	union
-	{
-		float	f;
-		byte	b[4];
-	} dat1, dat2;
-
-
-	dat1.f = f;
-	dat2.b[0] = dat1.b[3];
-	dat2.b[1] = dat1.b[2];
-	dat2.b[2] = dat1.b[1];
-	dat2.b[3] = dat1.b[0];
-	return dat2.f;
-}
-
-float FloatNoSwap (float f)
-{
-	return f;
-}
-#endif
 
 /*
 ==============================================================================
@@ -1458,46 +1386,6 @@ COM_Init
 */
 void COM_Init (void)
 {
-#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
-	int	i = 0x12345678;
-		/*    U N I X */
-
-	/*
-	BE_ORDER:  12 34 56 78
-		   U  N  I  X
-
-	LE_ORDER:  78 56 34 12
-		   X  I  N  U
-
-	PDP_ORDER: 34 12 78 56
-		   N  U  X  I
-	*/
-	if ( *(char *)&i == 0x12 )
-		host_bigendian = true;
-	else if ( *(char *)&i == 0x78 )
-		host_bigendian = false;
-	else /* if ( *(char *)&i == 0x34 ) */
-		Sys_Error ("Unsupported endianism.");
-
-	if (host_bigendian)
-	{
-		BigShort = ShortNoSwap;
-		LittleShort = ShortSwap;
-		BigLong = LongNoSwap;
-		LittleLong = LongSwap;
-		BigFloat = FloatNoSwap;
-		LittleFloat = FloatSwap;
-	}
-	else /* assumed LITTLE_ENDIAN. */
-	{
-		BigShort = ShortSwap;
-		LittleShort = ShortNoSwap;
-		BigLong = LongSwap;
-		LittleLong = LongNoSwap;
-		BigFloat = FloatSwap;
-		LittleFloat = FloatNoSwap;
-	}
-#endif
 	if (COM_CheckParm("-fitz"))
 		fitzmode = true;
 }

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -197,7 +197,7 @@ static inline short BigShort (short s)
 
 static inline short LittleShort (short s)
 {
-#if defined(__LITTLE_ENDIAN__)
+#if defined(__BIG_ENDIAN__)
 	s = bswap16(s);
 #endif
 	return s;
@@ -213,7 +213,7 @@ static inline int BigLong (int l)
 
 static inline int LittleLong (int l)
 {
-#if defined(__LITTLE_ENDIAN__)
+#if defined(__BIG_ENDIAN__)
 	l = bswap32(l);
 #endif
 	return l;
@@ -234,7 +234,7 @@ static inline float BigFloat (float f)
 
 static inline float LittleFloat (float f)
 {
-#if defined(__LITTLE_ENDIAN__)
+#if defined(__BIG_ENDIAN__)
 	union {
 		float			f;
 		unsigned long	l;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -171,6 +171,7 @@ void Vec_Free (void **pvec);
 
 //============================================================================
 
+#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
 extern	qboolean		host_bigendian;
 
 extern	short	(*BigShort) (short l);
@@ -179,6 +180,71 @@ extern	int	(*BigLong) (int l);
 extern	int	(*LittleLong) (int l);
 extern	float	(*BigFloat) (float l);
 extern	float	(*LittleFloat) (float l);
+#else
+#if defined(__BIG_ENDIAN__)
+#define host_bigendian 1
+#else
+#define host_bigendian 0
+#endif
+
+static inline short BigShort (short s)
+{
+#if defined(__LITTLE_ENDIAN__)
+	s = bswap16(s);
+#endif
+	return s;
+}
+
+static inline short LittleShort (short s)
+{
+#if defined(__LITTLE_ENDIAN__)
+	s = bswap16(s);
+#endif
+	return s;
+}
+
+static inline int BigLong (int l)
+{
+#if defined(__LITTLE_ENDIAN__)
+	l = bswap32(l);
+#endif
+	return l;
+}
+
+static inline int LittleLong (int l)
+{
+#if defined(__LITTLE_ENDIAN__)
+	l = bswap32(l);
+#endif
+	return l;
+}
+
+static inline float BigFloat (float f)
+{
+#if defined(__LITTLE_ENDIAN__)
+	union {
+		float			f;
+		unsigned long	l;
+	} u = { f };
+	u.l = bswap32(u.l);
+	f = u.f;
+#endif
+	return f;
+}
+
+static inline float LittleFloat (float f)
+{
+#if defined(__LITTLE_ENDIAN__)
+	union {
+		float			f;
+		unsigned long	l;
+	} u = { f };
+	u.l = bswap32(u.l);
+	f = u.f;
+#endif
+	return f;
+}
+#endif
 
 //============================================================================
 

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -177,10 +177,10 @@ void Vec_Free (void **pvec);
 #define host_bigendian 0
 #endif
 
-#define BigShort(s)    SDL_SwapBE16((s))
-#define LittleShort(s) SDL_SwapLE16((s))
-#define BigLong(l)     SDL_SwapBE32((l))
-#define LittleLong(l)  SDL_SwapLE32((l))
+#define BigShort(s)    ((short)SDL_SwapBE16((s)))
+#define LittleShort(s) ((short)SDL_SwapLE16((s)))
+#define BigLong(l)     ((int)SDL_SwapBE32((l)))
+#define LittleLong(l)  ((int)SDL_SwapLE32((l)))
 #define BigFloat(f)    SDL_SwapFloatBE((f))
 #define LittleFloat(f) SDL_SwapFloatLE((f))
 

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -171,80 +171,18 @@ void Vec_Free (void **pvec);
 
 //============================================================================
 
-#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
-extern	qboolean		host_bigendian;
-
-extern	short	(*BigShort) (short l);
-extern	short	(*LittleShort) (short l);
-extern	int	(*BigLong) (int l);
-extern	int	(*LittleLong) (int l);
-extern	float	(*BigFloat) (float l);
-extern	float	(*LittleFloat) (float l);
-#else
-#if defined(__BIG_ENDIAN__)
+#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
 #define host_bigendian 1
 #else
 #define host_bigendian 0
 #endif
 
-static inline short BigShort (short s)
-{
-#if defined(__LITTLE_ENDIAN__)
-	s = bswap16(s);
-#endif
-	return s;
-}
-
-static inline short LittleShort (short s)
-{
-#if defined(__BIG_ENDIAN__)
-	s = bswap16(s);
-#endif
-	return s;
-}
-
-static inline int BigLong (int l)
-{
-#if defined(__LITTLE_ENDIAN__)
-	l = bswap32(l);
-#endif
-	return l;
-}
-
-static inline int LittleLong (int l)
-{
-#if defined(__BIG_ENDIAN__)
-	l = bswap32(l);
-#endif
-	return l;
-}
-
-static inline float BigFloat (float f)
-{
-#if defined(__LITTLE_ENDIAN__)
-	union {
-		float			f;
-		unsigned long	l;
-	} u = { f };
-	u.l = bswap32(u.l);
-	f = u.f;
-#endif
-	return f;
-}
-
-static inline float LittleFloat (float f)
-{
-#if defined(__BIG_ENDIAN__)
-	union {
-		float			f;
-		unsigned long	l;
-	} u = { f };
-	u.l = bswap32(u.l);
-	f = u.f;
-#endif
-	return f;
-}
-#endif
+#define BigShort(s)    SDL_SwapBE16((s))
+#define LittleShort(s) SDL_SwapLE16((s))
+#define BigLong(l)     SDL_SwapBE32((l))
+#define LittleLong(l)  SDL_SwapLE32((l))
+#define BigFloat(f)    SDL_SwapFloatBE((f))
+#define LittleFloat(f) SDL_SwapFloatLE((f))
 
 //============================================================================
 

--- a/Quake/q_stdinc.h
+++ b/Quake/q_stdinc.h
@@ -69,6 +69,12 @@
 #include <stdarg.h>
 #include <string.h>
 #include <float.h>
+#if defined __has_include
+#if __has_include(<endian.h>)
+#include <endian.h>
+#endif
+#endif
+
 
 /*==========================================================================*/
 
@@ -245,6 +251,46 @@ typedef ptrdiff_t	ssize_t;
 
 /*==========================================================================*/
 
+/* endianness */
+
+#if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+#if (defined(__BYTE_ORDER__)  && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
+    (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN) || \
+    (defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN) || \
+    (defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN) || \
+     defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__)
+#define __BIG_ENDIAN__
+#elif (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
+      (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
+      (defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN) || \
+      (defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN) || \
+       defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
+       defined(_M_IX86) || defined(_M_X64) || \
+       defined(_M_ARM) || defined(_M_ARM64)
+#define __LITTLE_ENDIAN__
+#endif
+#endif
+
+#if defined(__BIG_ENDIAN__) && defined(__LITTLE_ENDIAN__)
+#error "__BIG_ENDIAN__ and __LITTLE_ENDIAN__ can't be defined together."
+#elif defined(__BIG_ENDIAN__) || defined(__LITTLE_ENDIAN__)
+#if defined(_MSC_VER)
+#define bswap16(x) _byteswap_ushort((x))
+#define bswap32(x) _byteswap_ulong((x))
+#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+#define bswap16(x) __builtin_bswap16((x))
+#define bswap32(x) __builtin_bswap32((x))
+#elif defined(__has_builtin) && __has_builtin(__builtin_bswap32)
+#define bswap16(x) __builtin_bswap16((x))
+#define bswap32(x) __builtin_bswap32((x))
+#else
+#warning "No built-in byte swapping support. Endianness will be determined at run-time."
+#undef __BIG_ENDIAN__
+#undef __LITTLE_ENDIAN__
+#endif
+#endif
+
+/*==========================================================================*/
 
 #endif	/* __QSTDINC_H */
 

--- a/Quake/q_stdinc.h
+++ b/Quake/q_stdinc.h
@@ -69,11 +69,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <float.h>
-#if defined __has_include
-#if __has_include(<endian.h>)
-#include <endian.h>
-#endif
-#endif
+#include <SDL_endian.h>
 
 
 /*==========================================================================*/
@@ -251,46 +247,6 @@ typedef ptrdiff_t	ssize_t;
 
 /*==========================================================================*/
 
-/* endianness */
-
-#if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-#if (defined(__BYTE_ORDER__)  && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
-    (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN) || \
-    (defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN) || \
-    (defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN) || \
-     defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__)
-#define __BIG_ENDIAN__
-#elif (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
-      (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
-      (defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN) || \
-      (defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN) || \
-       defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
-       defined(_M_IX86) || defined(_M_X64) || \
-       defined(_M_ARM) || defined(_M_ARM64)
-#define __LITTLE_ENDIAN__
-#endif
-#endif
-
-#if defined(__BIG_ENDIAN__) && defined(__LITTLE_ENDIAN__)
-#error "__BIG_ENDIAN__ and __LITTLE_ENDIAN__ can't be defined together."
-#elif defined(__BIG_ENDIAN__) || defined(__LITTLE_ENDIAN__)
-#if defined(_MSC_VER)
-#define bswap16(x) _byteswap_ushort((x))
-#define bswap32(x) _byteswap_ulong((x))
-#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
-#define bswap16(x) __builtin_bswap16((x))
-#define bswap32(x) __builtin_bswap32((x))
-#elif defined(__has_builtin) && __has_builtin(__builtin_bswap32)
-#define bswap16(x) __builtin_bswap16((x))
-#define bswap32(x) __builtin_bswap32((x))
-#else
-#warning "No built-in byte swapping support. Endianness will be determined at run-time."
-#undef __BIG_ENDIAN__
-#undef __LITTLE_ENDIAN__
-#endif
-#endif
-
-/*==========================================================================*/
 
 #endif	/* __QSTDINC_H */
 


### PR DESCRIPTION
This change is minor, but allows the compiler to eliminate all the calls to (Big|Little)(Short|Long|Float) when endianness can be determined at compile-time. If endianness can't be determined, compilation falls back to the original function pointer implementation with run-time endianness detection.