### PR TITLE
Model Warning and Limit Increases

### DIFF
--- a/Quake/cl_parse.c
+++ b/Quake/cl_parse.c
@@ -402,7 +402,7 @@ void CL_ParseServerInfo (void)
 		cl.model_precache[i] = Mod_ForName (model_precache[i], false);
 		if (cl.model_precache[i] == NULL)
 		{
-			Host_Error ("Model %s not found", model_precache[i]);
+			Con_Warning("Model %s not found.\n", model_precache[i]); // Qmaster -- was Host_Error
 		}
 		CL_KeepaliveMessage ();
 	}

--- a/Quake/gl_model.h
+++ b/Quake/gl_model.h
@@ -328,7 +328,7 @@ typedef struct mtriangle_s {
 } mtriangle_t;
 
 
-#define	MAX_SKINS	32
+#define	MAX_SKINS	256 // Qmaster -- was 32
 typedef struct {
 	int			ident;
 	int			version;

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -109,8 +109,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	MAX_EDICTS	32000		// johnfitz -- highest allowed value for max_edicts cvar
 						// ents past 8192 can't play sounds in the standard protocol
 #define	MAX_LIGHTSTYLES	64
-#define	MAX_MODELS	2048		// johnfitz -- was 256
-#define	MAX_SOUNDS	2048		// johnfitz -- was 256
+#define	MAX_MODELS	16384 // Qmaster -- was 2048 // johnfitz -- was 256
+#define	MAX_SOUNDS	16384 // Qmaster -- was 2048 // johnfitz -- was 256
 
 #define	SAVEGAME_COMMENT_LENGTH	39
 

--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -64,7 +64,7 @@ int		s_rawend;
 portable_samplepair_t	s_rawsamples[MAX_RAW_SAMPLES];
 
 
-#define	MAX_SFX		1024
+#define	MAX_SFX		16384 // Qmaster -- was 1024
 static sfx_t	*known_sfx = NULL;	// hunk allocated [MAX_SFX]
 static int	num_sfx;
 

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -124,13 +124,13 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 	info = GetWavinfo (s->name, data, com_filesize);
 	if (info.channels != 1)
 	{
-		Con_Printf ("%s is a stereo sample\n",s->name);
+		Con_Printf ("%s is a stereo sample, not loaded!\n",s->name); // Qmaster -- clarified why this message is printed
 		return NULL;
 	}
 
 	if (info.width != 1 && info.width != 2)
 	{
-		Con_Printf("%s is not 8 or 16 bit\n", s->name);
+		Con_Printf("%s is not 8 or 16 bit, not loaded!\n", s->name); // Qmaster -- clarified why this message is printed
 		return NULL;
 	}
 
@@ -141,7 +141,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 
 	if (info.samples == 0 || len == 0)
 	{
-		Con_Printf("%s has zero samples\n", s->name);
+		Con_Printf("%s has zero samples, not loaded!\n", s->name); // Qmaster -- clarified why this message is printed
 		return NULL;
 	}
 


### PR DESCRIPTION
Warn on model load issues rather than error out.  Quality of life feature for mod development.

Increase limits for sounds, models, skins, to better accommodate large mods and maps and also since tools are able to create standard mdl files with more than vanilla engine limits.  There are some mods who may not exceed these limits but some maps that utilize large mods can have large numbers of custom sounds and models.