### PR TITLE
Hide fullscreen cursor when cl_mousemenu is 0

### DIFF
--- a/Quake/console.c
+++ b/Quake/console.c
@@ -128,7 +128,7 @@ void Con_ToggleConsole_f (void)
 	}
 	else
 	{
-		IN_Deactivate();
+		IN_DeactivateForConsole();
 		key_dest = key_console;
 	}
 
@@ -1285,7 +1285,7 @@ void Con_NotifyBox (const char *text)
 	Con_Printf ("Press a key.\n");
 	Con_Printf ("%s", Con_Quakebar(40)); //johnfitz
 
-	IN_Deactivate();
+	IN_DeactivateForConsole();
 	key_dest = key_console;
 
 	Key_BeginInputGrab ();

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -685,8 +685,10 @@ static void VID_Restart (void)
 //
 // update mouse grab
 //
-	if (key_dest == key_console || key_dest == key_menu)
-		IN_Deactivate();
+	if (key_dest == key_console)
+		IN_DeactivateForConsole();
+	else if (key_dest == key_menu)
+		IN_DeactivateForMenu();
 }
 
 /*
@@ -1628,8 +1630,10 @@ void	VID_Toggle (void)
 		VID_SyncCvars();
 
 		// update mouse grab
-		if (key_dest == key_console || key_dest == key_menu)
-			IN_Deactivate();
+		if (key_dest == key_console)
+			IN_DeactivateForConsole();
+		else if (key_dest == key_menu)
+			IN_DeactivateForMenu();
 	}
 	else
 	{
@@ -2513,7 +2517,7 @@ VID_Menu_f
 */
 static void VID_Menu_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_video;
 	m_entersound = true;

--- a/Quake/input.h
+++ b/Quake/input.h
@@ -51,7 +51,9 @@ void IN_ClearStates (void);
 void IN_Activate (void);
 
 // called when the app becomes inactive
-void IN_Deactivate (void);
+void IN_Deactivate (qboolean free_cursor);
+void IN_DeactivateForConsole (void);
+void IN_DeactivateForMenu (void);
 
 #endif	/* _QUAKE_INPUT_H */
 

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -1237,7 +1237,7 @@ void Key_UpdateForDest (void)
 		if (cls.state != ca_connected)
 		{
 			forced = true;
-			IN_Deactivate();
+			IN_DeactivateForConsole();
 			key_dest = key_console;
 			break;
 		}

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -617,7 +617,7 @@ void M_Menu_Main_f (void)
 		m_save_demonum = cls.demonum;
 		cls.demonum = -1;
 	}
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_main;
 	m_entersound = true;
@@ -783,7 +783,7 @@ int	m_singleplayer_cursor;
 
 void M_Menu_SinglePlayer_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_singleplayer;
 	m_entersound = true;
@@ -917,7 +917,7 @@ void M_Menu_Load_f (void)
 	m_entersound = true;
 	m_state = m_load;
 
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	M_ScanSaves ();
 }
@@ -934,7 +934,7 @@ void M_Menu_Save_f (void)
 	m_entersound = true;
 	m_state = m_save;
 
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	M_ScanSaves ();
 }
@@ -1077,7 +1077,7 @@ int m_skill_cursor;
 
 void M_Menu_Skill_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_skill;
 	m_entersound = true;
@@ -1159,7 +1159,7 @@ int	m_multiplayer_cursor;
 
 void M_Menu_MultiPlayer_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_multiplayer;
 	m_entersound = true;
@@ -1256,7 +1256,7 @@ int		setup_bottom;
 
 void M_Menu_Setup_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_setup;
 	m_entersound = true;
@@ -1458,7 +1458,7 @@ const char *net_helpMessage [] =
 
 void M_Menu_Net_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_net;
 	m_entersound = true;
@@ -1604,7 +1604,7 @@ float target_scale_frac;
 
 void M_Menu_Options_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_options;
 	m_entersound = true;
@@ -2132,7 +2132,7 @@ static qboolean	bind_grab;
 
 void M_Menu_Keys_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_keys;
 	m_entersound = true;
@@ -2267,7 +2267,7 @@ void M_Keys_Key (int k)
 		}
 
 		bind_grab = false;
-		IN_Deactivate(); // deactivate because we're returning to the menu
+		IN_DeactivateForMenu(); // deactivate because we're returning to the menu
 		return;
 	}
 
@@ -2341,7 +2341,7 @@ int		help_page;
 
 void M_Menu_Help_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_help;
 	m_entersound = true;
@@ -2449,7 +2449,7 @@ void M_Menu_Quit_f (void)
 	if (m_state == m_quit)
 		return;
 	wasInMenus = (key_dest == key_menu);
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_quit_prevstate = m_state;
 	m_state = m_quit;
@@ -2500,7 +2500,7 @@ void M_Quit_Char (int key)
 
 	case 'y':
 	case 'Y':
-		IN_Deactivate();
+		IN_DeactivateForConsole();
 		key_dest = key_console;
 		Host_Quit_f ();
 		break;
@@ -2560,7 +2560,7 @@ char	lanConfig_joinname[22];
 
 void M_Menu_LanConfig_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_lanconfig;
 	m_entersound = true;
@@ -2930,7 +2930,7 @@ double m_serverInfoMessageTime;
 
 void M_Menu_GameOptions_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_gameoptions;
 	m_entersound = true;
@@ -3249,7 +3249,7 @@ double		searchCompleteTime;
 
 void M_Menu_Search_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_search;
 	m_entersound = false;
@@ -3310,7 +3310,7 @@ qboolean slist_sorted;
 
 void M_Menu_ServerList_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	m_state = m_slist;
 	m_entersound = true;
@@ -3488,7 +3488,7 @@ static void M_Mods_Init (void)
 
 void M_Menu_Mods_f (void)
 {
-	IN_Deactivate();
+	IN_DeactivateForMenu();
 	key_dest = key_menu;
 	modsmenu.prev = m_state;
 	m_state = m_mods;

--- a/Quake/net_dgrm.c
+++ b/Quake/net_dgrm.c
@@ -1395,7 +1395,7 @@ ErrorReturn2:
 	dfunc.Close_Socket(newsock);
 	if (m_return_onerror)
 	{
-		IN_Deactivate();
+		IN_DeactivateForMenu();
 		key_dest = key_menu;
 		m_state = m_return_state;
 		m_return_onerror = false;


### PR DESCRIPTION
This is for those who prefer the original look (without cursor) and behavior. Also, it can be a bit confusing to see the mouse cursor while fullscreen and `cl_mousemenu` is set to `0`. For example: Is `cl_mousemenu` not working? Has the game lost focus, so another app or the desktop has focus instead?

Behavior changed:
* When fullscreen and `cl_mousemenu` is `0`, the cursor is hidden.
* When fullscreen and the console is displayed, the cursor is hidden regardless of the `cl_mousemenu` setting.

Behavior not changed:
* When fullscreen and `cl_mousemenu` is `1`, the cursor is shown at the menu.
* When in window mode, the cursor is displayed both at the menu and console.

Note: There seemed to be an order of operations issue that I didn't spend the time to track down with regards to the `cl_mousemenu` setting and the console/menu before starting a game. It seemed the `cl_mousemenu` setting was not being honored at the right time when changed at the console (in file `keys.c`), so toggling between the console and menu was required for the cursor to hide or show properly. To avoid that issue, I opted to always hide the cursor at the console unless in window mode. This seemed fine, since the cursor cannot interact with the console or console text.

Thank you for considering this!

Closes #121.