### PR TITLE
Change when to show/hide loading plaque

### DIFF
--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -1182,12 +1182,15 @@ void SCR_BeginLoadingPlaque (void)
 	if (cls.signon != SIGNONS)
 		return;
 
-// redraw with no console and the loading plaque
-	Con_ClearNotify ();
-	scr_centertime_off = 0;
-	scr_con_current = 0;
+	if (key_dest != key_console)
+	{
+		// redraw without the console and display the loading plaque
+		Con_ClearNotify ();
+		scr_centertime_off = 0;
+		scr_con_current = 0;
+		scr_drawloading = true;
+	}
 
-	scr_drawloading = true;
 	Sbar_Changed ();
 	SCR_UpdateScreen ();
 	scr_drawloading = false;

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -1247,8 +1247,6 @@ static void Host_Loadgame_f (void)
 	COM_AddExtension (relname, ".sav", sizeof(relname));
 	Con_Printf ("Loading game from %s...\n", relname);
 
-	SCR_BeginLoadingPlaque ();
-
 	q_snprintf (name, sizeof(name), "%s/%s", com_gamedir, relname);
 	
 // avoid leaking if the previous Host_Loadgame_f failed with a Host_Error
@@ -1260,7 +1258,6 @@ static void Host_Loadgame_f (void)
 	{
 		Con_Printf ("ERROR: couldn't open.\n");
 		Host_InvalidateSave (relname);
-		SCR_EndLoadingPlaque ();
 		return;
 	}
 
@@ -1275,9 +1272,11 @@ static void Host_Loadgame_f (void)
 		else
 			Host_Error ("Savegame is version %i, not %i", version, SAVEGAME_VERSION);
 		Host_InvalidateSave (relname);
-		SCR_EndLoadingPlaque ();
 		return;
 	}
+
+	SCR_BeginLoadingPlaque ();
+
 	data = COM_ParseStringNewline (data);
 	for (i = 0; i < NUM_SPAWN_PARMS; i++)
 		data = COM_ParseFloatNewline (data, &spawn_parms[i]);


### PR DESCRIPTION
I found that error messages cleared on load error and sounds temporarily stopped.

This patch postpones showing the loading plaque until after common error messages. The loading plaque is shown a little bit after loading technically starts, but that seems fine since it's also a UX technique to postpone loading indication a bit to make loading seem faster. This has three main benefits:

1. Error messages are shown in-game and not cleared on error.
2. The loading plaque is not temporarily shown when there is a common error, such as file not found or version mismatch.
3. Sounds do not temporarily stop (due to a line in `SCR_BeginLoadingPlaque()`).

At the console, this patch keeps the console from "jumping" (closing and opening again) during load, restart, etc. and the loading plaque is not shown.