### PR TITLE
Ability to filter "r_showbboxes 1" entities by classname substring.

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -98,6 +98,7 @@ cvar_t	r_oldskyleaf = {"r_oldskyleaf", "0", CVAR_NONE};
 cvar_t	r_drawworld = {"r_drawworld", "1", CVAR_NONE};
 cvar_t	r_showtris = {"r_showtris", "0", CVAR_NONE};
 cvar_t	r_showbboxes = {"r_showbboxes", "0", CVAR_NONE};
+cvar_t	r_showbboxes_filter = {"r_showbboxes_filter", "", CVAR_NONE};
 cvar_t	r_lerpmodels = {"r_lerpmodels", "1", CVAR_ARCHIVE};
 cvar_t	r_lerpmove = {"r_lerpmove", "1", CVAR_ARCHIVE};
 cvar_t	r_nolerp_list = {"r_nolerp_list", "progs/flame.mdl,progs/flame2.mdl,progs/braztall.mdl,progs/brazshrt.mdl,progs/longtrch.mdl,progs/flame_pyre.mdl,progs/v_saw.mdl,progs/v_xfist.mdl,progs/h2stuff/newfire.mdl", CVAR_NONE};
@@ -1213,6 +1214,37 @@ static void R_EmitWireBox (const vec3_t mins, const vec3_t maxs, uint32_t color)
 
 /*
 ================
+R_ShowBoundingBoxesFilter
+
+r_showbboxes_filter "artifact,=trigger_secret"
+================
+*/
+char *r_showbboxes_filter_strings = NULL;
+
+static qboolean R_ShowBoundingBoxesFilter (edict_t *ed)
+{
+	if (!r_showbboxes_filter_strings)
+		return true;
+
+	if (!ed->v.classname)
+		return false;
+
+	const char *classname = PR_GetString (ed->v.classname);
+	char *str = r_showbboxes_filter_strings;
+	qboolean is_allowed = false;
+	while (*str && !is_allowed)
+	{
+		if (*str == '=')
+			is_allowed = !strcmp (classname, str + 1);
+		else
+			is_allowed = strstr (classname, str) != NULL;
+		str += strlen (str) + 1;
+	}
+	return is_allowed;
+}
+
+/*
+================
 R_ShowBoundingBoxes -- johnfitz
 
 draw bounding boxes -- the server-side boxes, not the renderer cullboxes
@@ -1252,6 +1284,9 @@ static void R_ShowBoundingBoxes (void)
 		if (ed == sv_player)
 			continue;
 
+		if (!R_ShowBoundingBoxesFilter(ed))
+			continue;
+
 		if (pvs)
 		{
 			qboolean inpvs =
@@ -1278,6 +1313,8 @@ static void R_ShowBoundingBoxes (void)
 						break;
 				}
 			}
+			if (ed->v.health > 0)
+				color = 0xff0000ff;
 		}
 		else
 			color = 0xffffffff;

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1226,21 +1226,22 @@ static qboolean R_ShowBoundingBoxesFilter (edict_t *ed)
 	if (!r_showbboxes_filter_strings)
 		return true;
 
-	if (!ed->v.classname)
-		return false;
-
-	const char *classname = PR_GetString (ed->v.classname);
-	char *str = r_showbboxes_filter_strings;
-	qboolean is_allowed = false;
-	while (*str && !is_allowed)
+	if (ed->v.classname)
 	{
-		if (*str == '=')
-			is_allowed = !strcmp (classname, str + 1);
-		else
-			is_allowed = strstr (classname, str) != NULL;
-		str += strlen (str) + 1;
+		const char *classname = PR_GetString (ed->v.classname);
+		char *str = r_showbboxes_filter_strings;
+		qboolean is_allowed = false;
+		while (*str && !is_allowed)
+		{
+			if (*str == '=')
+				is_allowed = !strcmp (classname, str + 1);
+			else
+				is_allowed = strstr (classname, str) != NULL;
+			str += strlen (str) + 1;
+		}
+		return is_allowed;
 	}
-	return is_allowed;
+	return false;
 }
 
 /*

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -67,23 +67,25 @@ static void R_SetShowbboxesFilter_f (cvar_t *var)
 
 	if (*var->string)
 	{
+		char *filter, *p, *token;
+		const char *delim = ",";
 		int len = strlen (var->string);
 		int size = len + 2;
+
 		r_showbboxes_filter_strings = (char *) malloc(size);
 		if (!r_showbboxes_filter_strings)
 			Sys_Error ("R_SetShowbboxesFilter_f: malloc() failed on %d bytes", size);
 
-		char *filter = strdup(var->string);
+		filter = strdup(var->string);
 		if (!filter)
 			Sys_Error ("R_SetShowbboxesFilter_f: strdup() failed on %d bytes", len + 1);
 
-		char *p = r_showbboxes_filter_strings;
-		const char *delim = ",";
-		char *token = strtok (filter, delim);
+		p = r_showbboxes_filter_strings;
+		token = strtok (filter, delim);
 		while (token != NULL)
 		{
 			strcpy (p, token);
-			p += strlen(token) + 1;
+			p += strlen (token) + 1;
 			token = strtok (NULL, delim);
 		}
 		*p = '\0';

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -36,6 +36,7 @@ extern cvar_t r_oldskyleaf;
 extern cvar_t r_drawworld;
 extern cvar_t r_showtris;
 extern cvar_t r_showbboxes;
+extern cvar_t r_showbboxes_filter;
 extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
 extern cvar_t r_nolerp_list;
@@ -51,6 +52,34 @@ extern cvar_t r_simd;
 qboolean use_simd;
 
 extern gltexture_t *playertextures[MAX_SCOREBOARD]; //johnfitz
+
+/*
+====================
+R_SetShowbboxesFilter_f
+====================
+*/
+static void R_SetShowbboxesFilter_f (cvar_t *var)
+{
+	extern char *r_showbboxes_filter_strings;
+
+	free (r_showbboxes_filter_strings);
+	r_showbboxes_filter_strings = NULL;
+
+	if (*var->string)
+	{
+		int size = strlen (var->string) + 2;
+		r_showbboxes_filter_strings = (char *) malloc(size);
+		if (!r_showbboxes_filter_strings)
+			Sys_Error ("R_SetShowbboxesFilter_f: malloc() failed on %d bytes", size);
+
+		strcpy (r_showbboxes_filter_strings, var->string);
+		r_showbboxes_filter_strings[size - 1] = '\0';
+
+		char *p = r_showbboxes_filter_strings;
+		while ((p = strchr (p, ',')) != NULL)
+			*p++ = '\0';
+	}
+}
 
 /*
 ====================
@@ -220,6 +249,8 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_drawworld);
 	Cvar_RegisterVariable (&r_showtris);
 	Cvar_RegisterVariable (&r_showbboxes);
+	Cvar_RegisterVariable (&r_showbboxes_filter);
+	Cvar_SetCallback (&r_showbboxes_filter, R_SetShowbboxesFilter_f);
 	Cvar_RegisterVariable (&gl_farclip);
 	Cvar_RegisterVariable (&gl_fullbrights);
 	Cvar_SetCallback (&gl_fullbrights, GL_Fullbrights_f);

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -67,17 +67,28 @@ static void R_SetShowbboxesFilter_f (cvar_t *var)
 
 	if (*var->string)
 	{
-		int size = strlen (var->string) + 2;
+		int len = strlen (var->string);
+		int size = len + 2;
 		r_showbboxes_filter_strings = (char *) malloc(size);
 		if (!r_showbboxes_filter_strings)
 			Sys_Error ("R_SetShowbboxesFilter_f: malloc() failed on %d bytes", size);
 
-		strcpy (r_showbboxes_filter_strings, var->string);
-		r_showbboxes_filter_strings[size - 1] = '\0';
+		char *filter = strdup(var->string);
+		if (!filter)
+			Sys_Error ("R_SetShowbboxesFilter_f: strdup() failed on %d bytes", len + 1);
 
 		char *p = r_showbboxes_filter_strings;
-		while ((p = strchr (p, ',')) != NULL)
-			*p++ = '\0';
+		const char *delim = ",";
+		char *token = strtok (filter, delim);
+		while (token != NULL)
+		{
+			strcpy (p, token);
+			p += strlen(token) + 1;
+			token = strtok (NULL, delim);
+		}
+		*p = '\0';
+
+		free(filter);
 	}
 }
 


### PR DESCRIPTION
Added `r_showbboxes_filter` config variable for filtering `r_showbboxes 1` entities by classname substring. Several classnames can be separated by commas, start with "=" for exact match. Also, bbox lines color for entities with health>0 was changed to red.

Usage examples:
`r_showbboxes_filter secret` for all entities with "secret" substring in its classname, "trigger_secret" for example.

`r_showbboxes_filter artifact,=monster_enforcer` for quad/penta/invis and enforcer guy.

https://www.youtube.com/watch?v=dMc5tf96bWY
