### PR TITLE
don't draw bounding boxes for freed edicts

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1284,8 +1284,8 @@ static void R_ShowBoundingBoxes (void)
 
 	for (i=1, ed=NEXT_EDICT(qcvm->edicts) ; i<qcvm->num_edicts ; i++, ed=NEXT_EDICT(ed))
 	{
-		if (ed == sv_player)
-			continue;
+		if (ed == sv_player || ed->free)
+			continue; // don't draw player's own bbox or freed edicts
 
 		if (!R_ShowBoundingBoxesFilter(ed))
 			continue;


### PR DESCRIPTION
Showing the issue:
https://www.youtube.com/watch?v=g6CWBFhEcG4

Fixed in vkQuake, but not in a separate commit.
https://github.com/Novum/vkQuake/commit/7434dbf2113a5b98a5f46e6fff770df1d0db5dd7 - r_showbboxes: display edict numbers
https://github.com/Novum/vkQuake/blob/master/Quake/gl_rmain.c#L655

