### PR TITLE
Add continuous integration via GitHub Actions

### DIFF
--- a/.github/workflows/linux_ci.yml
+++ b/.github/workflows/linux_ci.yml
@@ -1,0 +1,16 @@
+name: Linux CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: Linux / ${{ matrix.compiler }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ["clang", "gcc"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Dependencies
+      run: sudo apt update && sudo apt install libcurl4-openssl-dev libmad0-dev libsdl2-dev libvorbis-dev
+    - name: Build
+      run: make --jobs=3 --keep-going --directory=Quake CC=${{ matrix.compiler }}

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -1,0 +1,14 @@
+name: macOS CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: macOS
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Dependencies
+      run: brew install libvorbis mad sdl2
+    - name: Build
+      run: make --jobs=3 --keep-going --directory=Quake COMMON_LIBS="-framework CoreFoundation -framework IOKit -framework OpenGL -Wl,-alias -Wl,_SDL_main -Wl,_main"

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -1,0 +1,24 @@
+name: Windows CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: Windows / ${{ matrix.platform }}
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [x64, Win32]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $msbuild = & "$vswhere" -latest -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe | select-object -first 1
+        $options = @( `
+          '-property:Configuration=Release', `
+          '-property:Platform=${{ matrix.platform }}', `
+          '-maxcpucount', `
+          '-verbosity:minimal' `
+        )
+        & $msbuild Windows\VisualStudio\ironwail.sln $options
+        if (-not $?) { throw "Build failed" }


### PR DESCRIPTION
* Windows workflow builds 32- and 64-bit versions using Visual Studio solution
* Linux workflow builds 64-bit version with GCC and Clang
* macOS workflow is for reference purposes only. There is no sense to fix Makefile because OpenGL version is limited to 4.1 anyway

Links to [Windows](https://github.com/alexey-lysiuk/quakespasm/actions/runs/3928400681), [Linux](https://github.com/alexey-lysiuk/quakespasm/actions/runs/3928400687), [macOS](https://github.com/alexey-lysiuk/quakespasm/actions/runs/3928400679) builds.