### PR TITLE
Default `snd_filterquality` to `5` on all platforms for audio consistency

### DIFF
--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -83,13 +83,7 @@ cvar_t		snd_mixspeed = {"snd_mixspeed", "44100", CVAR_NONE};
 
 cvar_t		snd_waterfx = {"snd_waterfx", "1", CVAR_ARCHIVE};
 
-#if defined(_WIN32)
-#define SND_FILTERQUALITY_DEFAULT "5"
-#else
-#define SND_FILTERQUALITY_DEFAULT "1"
-#endif
-
-cvar_t		snd_filterquality = {"snd_filterquality", SND_FILTERQUALITY_DEFAULT,
+cvar_t		snd_filterquality = {"snd_filterquality", "5",
 								 CVAR_NONE};
 
 static	cvar_t	nosound = {"nosound", "0", CVAR_NONE};
@@ -185,7 +179,7 @@ void S_Init (void)
 	Cvar_RegisterVariable(&snd_mixspeed);
 	Cvar_RegisterVariable(&snd_filterquality);
 	Cvar_RegisterVariable(&snd_waterfx);
-	
+
 	if (safemode || COM_CheckParm("-nosound"))
 		return;
 
@@ -1102,4 +1096,3 @@ void S_BeginPrecaching (void)
 void S_EndPrecaching (void)
 {
 }
-


### PR DESCRIPTION
Previously, audio sounded significantly better on Windows than on macOS/Linux due to the default being 5 on Windows and 1 on macOS/Linux.

PS: We could also consider making `snd_filterquality` `CVAR_ARCHIVE` while we're at it.
