### PR TITLE
Cleanup correct multicurl handle

### DIFF
--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -642,7 +642,7 @@ done:
 	if (header)
 		curl_slist_free_all (header);
 	curl_easy_cleanup (curl);
-	curl_multi_cleanup (curl);
+	curl_multi_cleanup (multi_handle);
 
 	return !download->error && !still_running && download->response == 200;
 }


### PR DESCRIPTION
On Windows with a newer version of Curl (8.1.2), this call to destroy the wrong handle throws an exception.