### PR TITLE
Installation path fix for UNIX systems

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -290,7 +290,7 @@ OBJS += $(SYSOBJ_RES)
 # targets / rules
 # ---------------------------
 
-.PHONY:	clean debug release
+.PHONY:	clean debug release uninstall
 
 DEFAULT_TARGET := ironwail
 all: $(DEFAULT_TARGET)
@@ -315,8 +315,15 @@ clean: $(MAKEFILE)
 	$(RM) *.o *.d $(DEFAULT_TARGET)
 
 install:	ironwail
-	cp ironwail /usr/local/games/quake
-	cp ironwail.pak /usr/local/games/quake
+	mkdir -p /usr/local/games/quake/
+	mkdir -p /usr/local/share/ironwail
+	cp ironwail /usr/local/games/ironwail
+	cp ironwail.pak /usr/local/share/ironwail/ironwail.pak
+
+uninstall:
+	rm /usr/local/games/quake/ironwail.pak
+	rmdir /usr/local/games/quake
+	rm /usr/local/games/ironwail
 
 #---------------------------------------------------------------
 # include dependencies (if not running 'clean' target)

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -57,10 +57,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	IRONWAIL_VER_STRING		QS_STRINGIFY(IRONWAIL_VER_MAJOR) "." QS_STRINGIFY(IRONWAIL_VER_MINOR) "." QS_STRINGIFY(IRONWAIL_VER_PATCH) IRONWAIL_VER_SUFFIX
 
 #define CONSOLE_TITLE_STRING	"Ironwail " IRONWAIL_VER_STRING
-#define WINDOW_TITLE_STRING		"Quake/Ironwail " IRONWAIL_VER_STRING
-#define CONFIG_NAME				"ironwail.cfg"
-#define SCREENSHOT_PREFIX		"ironwail"
-#define ENGINE_PAK				"ironwail.pak"
+#define WINDOW_TITLE_STRING	  "Quake/Ironwail " IRONWAIL_VER_STRING
+#define CONFIG_NAME				    "ironwail.cfg"
+#define SCREENSHOT_PREFIX		  "ironwail"
+#if defined(__unix)
+#define ENGINE_PATH_UNIX      "/usr/local/share"
+#define ENGINE_PAK				    ENGINE_PATH_UNIX "/ironwail/ironwail.pak"
+#else
+#define ENFINE_PAK            "ironwail.pak"
+#endif
 #define ENGINE_USERDIR_WIN		"Ironwail"
 #define ENGINE_USERDIR_OSX		"Ironwail"
 #define ENGINE_USERDIR_UNIX		".ironwail"


### PR DESCRIPTION
While compiling and installing Ironwail on Linux the Makefile wasn't able to create the directory and put the files in the folders correctly.

This pull request should do these things:

* it assures to create the folder quake in the correct path. The
  folder `/usr/local/games` is common but not always present on every distribution and it is
  necessary to create it if not present.
* I created a folder `/usr/local/share` for the pak so the files useful for
  the binary are available on the standard path rather than on games.
* And I created a uninstall phony to remove everything.

This required some modification to the pak position in `quakedef.h` which are defined only
for `__unix`