### PR TITLE
Add gyro aim

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -67,8 +67,8 @@ cvar_t	joy_enable = { "joy_enable", "1", CVAR_ARCHIVE };
 cvar_t gyro_mode = {"gyro_mode", "0", CVAR_ARCHIVE};
 cvar_t gyro_turning_axis = {"gyro_turning_axis", "0", CVAR_ARCHIVE};
 
-cvar_t gyro_yawsensitivity = {"gyro_yawsensitivity", "1", CVAR_ARCHIVE};
-cvar_t gyro_pitchsensitivity= {"gyro_pitchsensitivity", "1", CVAR_ARCHIVE};
+cvar_t gyro_yawsensitivity = {"gyro_yawsensitivity", "2.5", CVAR_ARCHIVE};
+cvar_t gyro_pitchsensitivity= {"gyro_pitchsensitivity", "2.5", CVAR_ARCHIVE};
 
 cvar_t gyro_calibration_x = {"gyro_calibration_x", "0", CVAR_ARCHIVE};
 cvar_t gyro_calibration_y = {"gyro_calibration_y", "0", CVAR_ARCHIVE};

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -387,9 +387,9 @@ void IN_GyroActionUp (void)
 	}
 }
 
-void IN_UpdateGyroActive(void)
+void IN_UpdateGyroActive(cvar_t *var)
 {
-	switch ((int)gyro_mode.value)
+	switch ((int)var->value)
 	{
 		case 0:
 		case 1:
@@ -436,6 +436,7 @@ void IN_Init (void)
 	Cvar_RegisterVariable(&joy_enable);
 
 	Cvar_RegisterVariable(&gyro_mode);
+	Cvar_SetCallback(&gyro_mode, IN_UpdateGyroActive);
 	Cvar_RegisterVariable(&gyro_turning_axis);
 
 	Cvar_RegisterVariable(&gyro_yawsensitivity);

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -749,6 +749,18 @@ void IN_JoyMove (usercmd_t *cmd)
 
 void IN_GyroMove(usercmd_t *cmd)
 {
+	if (!joy_enable.value)
+		return;
+
+	if (!joy_active_controller)
+		return;
+
+	if (cl.paused || key_dest != key_game)
+		return;
+
+	if (CL_InCutscene ())
+		return;
+
 	float gyroViewFactor = (1.0f / M_PI) * host_frametime/0.01666f;
 
 	if (gyro_yaw)

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -1098,6 +1098,11 @@ void IN_SendKeyEvents (void)
 					SDL_Joystick *joy;
 					joy = SDL_GameControllerGetJoystick(joy_active_controller);
 					joy_active_instaceid = SDL_JoystickInstanceID(joy);
+					if (SDL_GameControllerHasLED(joy_active_controller))
+						{
+							// orange LED, seemed fitting for Quake
+							SDL_GameControllerSetLED(joy_active_controller, 80, 20, 0);
+						}
 				}
 			}
 			else

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -358,7 +358,8 @@ void IN_ShutdownJoystick (void)
 	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
 }
 
-void IN_GyroActionDown (void) {
+void IN_GyroActionDown (void)
+{
 	switch ((int)gyro_mode.value)
 	{
 		case 1:
@@ -366,11 +367,13 @@ void IN_GyroActionDown (void) {
 			return;
 		case 2:
 			gyro_active = false;
+			return;
 		case 4:
 			gyro_dir = -1;
 	}
 }
-void IN_GyroActionUp (void) {
+void IN_GyroActionUp (void)
+{
 	switch ((int)gyro_mode.value)
 	{
 		case 1:
@@ -378,8 +381,24 @@ void IN_GyroActionUp (void) {
 			return;
 		case 2:
 			gyro_active = true;
+			return;
 		case 4:
 			gyro_dir = 1;
+	}
+}
+
+void IN_UpdateGyroActive(void)
+{
+	switch ((int)gyro_mode.value)
+	{
+		case 0:
+		case 1:
+			gyro_active = false;
+			return;
+		case 2:
+		case 3:
+		case 4:
+			gyro_active = true;
 	}
 }
 

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -66,7 +66,6 @@ extern qboolean quake64;
 
 extern void StartCalibration(void);
 extern qboolean IsCalibrationZero(void);
-extern void IN_UpdateGyroActive(void);
 
 enum m_state_e m_state;
 extern qboolean	keydown[256];
@@ -3074,7 +3073,6 @@ static void GYRO_Menu_ChooseNextMode (int dir)
 		i = 0;
 
 	Cvar_SetValueQuick (&gyro_mode, i);
-	IN_UpdateGyroActive();
 }
 
 /*

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -64,6 +64,9 @@ extern char crosshair_char;
 
 extern qboolean quake64;
 
+extern void StartCalibration(void);
+extern qboolean IsCalibrationZero(void);
+
 enum m_state_e m_state;
 extern qboolean	keydown[256];
 int m_mousex, m_mousey;
@@ -3038,6 +3041,30 @@ static void GYRO_Menu_ToggleTurningAxis (int dir)
 	Cvar_SetValueQuick (&gyro_turning_axis, i);
 }
 
+/*
+================
+GYRO_Menu_Calibration
+
+starts gyro calibration
+================
+*/
+static void GYRO_Menu_Calibration(int dir)
+{
+	Con_Printf("Calibrating, please wait...");
+	StartCalibration();
+}
+
+/*
+================
+CalibrationFinishedCallback
+
+called from in_sdl once calibration is finished
+================
+*/
+void CalibrationFinishedCallback(void)
+{
+	Con_Printf("Calibration finished");
+}
 
 /*
 ================
@@ -3558,6 +3585,9 @@ void M_AdjustSliders (int dir)
 		break;
 	case GYRO_OPT_SENSY:
 		Cvar_SetValueQuick (&gyro_pitchsensitivity, CLAMP (MIN_GYRO_SENS, gyro_pitchsensitivity.value + dir * .1f, MAX_GYRO_SENS));
+		break;
+	case GYRO_OPT_CALIBRATE:
+		GYRO_Menu_Calibration(-dir);
 		break;
 
 	default:

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -66,6 +66,7 @@ extern qboolean quake64;
 
 extern void StartCalibration(void);
 extern qboolean IsCalibrationZero(void);
+extern void IN_UpdateGyroActive(void);
 
 enum m_state_e m_state;
 extern qboolean	keydown[256];
@@ -3073,6 +3074,7 @@ static void GYRO_Menu_ChooseNextMode (int dir)
 		i = 0;
 
 	Cvar_SetValueQuick (&gyro_mode, i);
+	IN_UpdateGyroActive();
 }
 
 /*

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -4219,7 +4219,7 @@ static const char* const bindnames[][2] =
 	{"centerview",		"Center view"},
 	{"zoom_in",			"Toggle zoom"},
 	{"+zoom",			"Quick zoom"},
-	{"+gyroaction",		"Gyro Action"},
+	{"+gyroaction",		"Gyro Off / On"},
 	{"",				""},
 	{"+attack",			"Attack"},
 	{"impulse 10",		"Next weapon"},

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -2991,6 +2991,59 @@ void M_Menu_Video_f (void)
 }
 
 //=============================================================================
+/* CALIBRATION SCREEN */
+
+qboolean calibrationComplete;
+double calibrationCompleteTime;
+
+void M_Menu_Calibration_f (void)
+{
+	IN_DeactivateForMenu();
+	m_state = m_calibration;
+	calibrationComplete = false;
+	Con_Printf("Calibrating, please wait...");
+	StartCalibration();
+}
+
+void M_Calibration_Draw (void)
+{
+	int x;
+	x = (320-27*8)/2;
+	M_DrawTextBox (x, 108, 27, 1);
+
+	if (! calibrationComplete)
+	{
+		x += 16;
+		M_Print (x, 116, "Calibrating, please wait...");
+	}
+	else
+	{
+		x += 32;
+		M_Print (x, 116, "Calibration Complete!");
+		if ((realtime - calibrationCompleteTime) > 2.0)
+			m_state = m_gyro;
+	}
+}
+
+void M_Calibration_Key (int key)
+{
+}
+
+/*
+================
+CalibrationFinishedCallback
+
+called from in_sdl once calibration is finished
+================
+*/
+void CalibrationFinishedCallback(void)
+{
+	Con_Printf("Calibration finished");
+	calibrationComplete = true;
+	calibrationCompleteTime = realtime;
+}
+
+//=============================================================================
 /* GYRO MENU */
 
 #define MIN_GYRO_SENS 0.1
@@ -3050,20 +3103,7 @@ starts gyro calibration
 */
 static void GYRO_Menu_Calibration(int dir)
 {
-	Con_Printf("Calibrating, please wait...");
-	StartCalibration();
-}
-
-/*
-================
-CalibrationFinishedCallback
-
-called from in_sdl once calibration is finished
-================
-*/
-void CalibrationFinishedCallback(void)
-{
-	Con_Printf("Calibration finished");
+	M_Menu_Calibration_f();
 }
 
 /*
@@ -4013,6 +4053,14 @@ void M_Options_Draw (void)
 
 		y += 8;
 	}
+
+	if (m_state == m_gyro)
+	{
+		M_Print (x, y, "To calibrate, place the controller");
+		y += 8;
+		M_Print (x, y, "on a flat, stable surface");
+	}
+
 }
 
 void M_Options_Key (int k)
@@ -6281,6 +6329,10 @@ void M_Draw (void)
 		M_Net_Draw ();
 		break;
 
+	case m_calibration:
+		M_Calibration_Draw ();
+		break;
+
 	case m_options:
 	case m_video:
 	case m_gyro:
@@ -6385,6 +6437,10 @@ void M_Keydown (int key)
 	case m_net:
 		M_Net_Key (key);
 		return;
+
+	case m_calibration:
+		M_Calibration_Key (key);
+		break;
 
 	case m_options:
 	case m_video:

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -3187,8 +3187,8 @@ void M_Menu_Gyro_f (void)
 													\
 	def(GYRO_OPT_SPACE1,		"")					\
 													\
-	def(GYRO_OPT_SENSX,			"Yaw Sensitivity")	\
-	def(GYRO_OPT_SENSY,			"Pitch Sensitivity")\
+	def(GYRO_OPT_SENSX,			"Yaw Speed")	\
+	def(GYRO_OPT_SENSY,			"Pitch Speed")\
 													\
 	def(GYRO_OPT_SPACE2,		"")					\
 													\

--- a/Quake/menu.h
+++ b/Quake/menu.h
@@ -37,6 +37,7 @@ enum m_state_e {
 	m_options,
 	m_video,
 	m_keys,
+	m_calibration,
 	m_gyro,
 	m_mods,
 	m_modinfo,

--- a/Quake/menu.h
+++ b/Quake/menu.h
@@ -37,6 +37,7 @@ enum m_state_e {
 	m_options,
 	m_video,
 	m_keys,
+	m_gyro,
 	m_mods,
 	m_modinfo,
 	m_help,


### PR DESCRIPTION
This is a basic implementation of gyro aiming for any controller supported by SDL that has it (meaning mainly Playstation and Switch controllers). This allows controller players precise aiming without any need for aim assist by tilting the controller.

It adds the following cvars for gyro options:
- gyro_mode
- gyro_turning_axis
- gyro_pitchsensitivity
- gyro_yawsensitivity
- gyro_calibration_x
- gyro_calibration_y
- gyro_calibration_z
as well as the +gyroaction command for binding a key to toggle the gyro.

It also adds an options menu specifically for these gyro options as well as manual calibration.

I've only been able to test this on Arch Linux with a Dualsense and and 8bitdo Pro 2 in Switch mode. Both work flawlessly.

This partially fixes #163, the gyro part not the adaptive triggers.

Most of the code is based on the implementation in Yamagi Quake 2. Thanks to @protocultor for that.
