### PR TITLE
Hide console mouse cursor when ui_mouse is 0

### DIFF
--- a/Quake/console.c
+++ b/Quake/console.c
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 
 extern qboolean	keydown[256];
+extern cvar_t	ui_mouse;
 
 int 		con_linewidth;
 
@@ -581,6 +582,10 @@ static void Con_SetMouseState (conmouse_t state)
 	int x, y;
 	conofs_t pos;
 
+	// When mouse cursor disabled, do not select text on click or open hotlinks.
+	if (!ui_mouse.value)
+		return;
+
 	if (con_mousestate == state)
 		return;
 
@@ -632,6 +637,10 @@ Mouse movement callback
 */
 void Con_Mousemove (int x, int y)
 {
+	// When mouse cursor disabled, do not select text on drag or set hotlinks.
+	if (!ui_mouse.value)
+		return;
+
 	if (con_mousestate == CMS_NOTPRESSED)
 	{
 		Con_SetHotLink (Con_GetLinkAtPixel (x, y));

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -274,7 +274,7 @@ void IN_Deactivate (qboolean free_cursor)
 
 void IN_DeactivateForConsole (void)
 {
-	IN_Deactivate(true);
+	IN_Deactivate(modestate == MS_WINDOWED || ui_mouse.value);
 }
 
 void IN_DeactivateForMenu (void)


### PR DESCRIPTION
When `ui_mouse` is set to `0` and using the console:
* Hides the mouse cursor.
* Disables click and select events, so the user isn't surprised by them working when the mouse cursor is hidden.

This is related to #130.