### PR TITLE
Improve gyro filter

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -3168,7 +3168,7 @@ void M_Calibration_Key (int key)
 #define MIN_GYRO_SENS			0.1f
 #define MAX_GYRO_SENS			8.f
 #define MIN_GYRO_NOISE_THRESH	0.f
-#define MAX_GYRO_NOISE_THRESH	5.f
+#define MAX_GYRO_NOISE_THRESH	12.f
 
 /*
 ================


### PR DESCRIPTION
This replaces the code for filtering of gyro samples. Instead of lerping with a previous sample, which can potentially feel laggy if only a little, it essentially applies a negative acceleration below the threshold as outlined by the gyro guru @JibbSmart [here](http://gyrowiki.jibbsmart.com/blog:good-gyro-controls-part-1:the-gyro-is-a-mouse#toc9).
This also makes the threshold act on the gyro vector's magnitude rather than each axis separately leading to a "round" threshold rather than a "square" one to put it in deadzone terms.

In a small effort to have some unification between different Quake games that implement this I also changed the default and max slider values to track the ones used in YQ2.