### PR TITLE
Pk3 support + improved filesystem abstraction

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -264,6 +264,7 @@ OBJS = strlcat.o \
 	crc.o \
 	cvar.o \
 	cfgfile.o \
+	filesys.o \
 	host.o \
 	host_cmd.o \
 	mathlib.o \

--- a/Quake/Makefile.w32
+++ b/Quake/Makefile.w32
@@ -270,6 +270,7 @@ OBJS = strlcat.o \
 	crc.o \
 	cvar.o \
 	cfgfile.o \
+	filesys.o \
 	host.o \
 	host_cmd.o \
 	mathlib.o \

--- a/Quake/Makefile.w64
+++ b/Quake/Makefile.w64
@@ -263,6 +263,7 @@ OBJS = strlcat.o \
 	crc.o \
 	cvar.o \
 	cfgfile.o \
+	filesys.o \
 	host.o \
 	host_cmd.o \
 	mathlib.o \

--- a/Quake/bgmusic.c
+++ b/Quake/bgmusic.c
@@ -340,7 +340,7 @@ void BGM_PlayCDtrack (byte track, qboolean looping)
 	//		goto _next;
 		q_snprintf(tmp, sizeof(tmp), "%s/track%02d.%s",
 				MUSIC_DIRNAME, (int)track, handler->ext);
-		if (! COM_FileExists(tmp, &path_id))
+		if (!QFS_FileExists(tmp, &path_id))
 			goto _next;
 		if (path_id > prev_id)
 		{

--- a/Quake/cfgfile.h
+++ b/Quake/cfgfile.h
@@ -22,14 +22,7 @@
 #ifndef __CFGFILE_H
 #define __CFGFILE_H
 
-int CFG_OpenConfig (const char *cfg_name);
-// opens the given config file. only one open config file is
-// kept: previosly opened one, if any, will be closed.
-
-void CFG_CloseConfig (void);
-// closes the currently open config file.
-
-void CFG_ReadCvars (const char **vars, int num_vars);
+void CFG_ReadCvars (const char *cfg_name, const char **vars, int num_vars);
 // reads the values of cvars in the given list from the opened
 // config file.
 

--- a/Quake/client.h
+++ b/Quake/client.h
@@ -134,8 +134,8 @@ typedef struct
 	qboolean	timedemo;
 	int		forcetrack;		// -1 = use normal cd track
 	char		demofilename[MAX_OSPATH];
-	FILE		*demofile;
-	qfileofs_t	demofilestart;	// for demos in pak files
+	qfshandle_t	*inpdemo;
+	FILE		*outpdemo;
 	qfileofs_t	demofilesize;
 	int		td_lastframe;		// to meter out one message a frame
 	int		td_startframe;		// host_framecount at start

--- a/Quake/cmd.c
+++ b/Quake/cmd.c
@@ -303,7 +303,7 @@ void Cmd_Exec_f (void)
 	// "exec config.cfg pls" will execute config.cfg
 	if (Cmd_Argc () == 2 && !strcmp (path, "config.cfg"))
 	{
-		f = (const char *)COM_LoadHunkFile (CONFIG_NAME, NULL);
+		f = (const char *)QFS_LoadHunkFile (CONFIG_NAME, NULL, NULL);
 		if (f)
 		{
 			path = CONFIG_NAME;
@@ -311,7 +311,7 @@ void Cmd_Exec_f (void)
 		}
 	}
 
-	f = (const char *)COM_LoadHunkFile (path, NULL);
+	f = (const char *)QFS_LoadHunkFile (path, NULL, NULL);
 	if (!f && !strcmp(Cmd_Argv(1), "default.cfg")) {
 		f = default_cfg;	/* see above.. */
 	}

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <errno.h>
 #include "miniz.h"
 #include "unicode_translit.h"
+#include "filesys.h"
 
 static const char	*largv[MAX_NUM_ARGVS + 1];
 static char	argvdummy[] = " ";
@@ -410,6 +411,16 @@ int q_snprintf (char *str, size_t size, const char *format, ...)
 	va_end (argptr);
 
 	return ret;
+}
+
+qboolean q_strascii (const char* str)
+{
+	while (*str++)
+	{
+		if ((byte)*str > 0x7f)
+			return false;
+	}
+	return true;
 }
 
 void Q_memset (void *dest, int fill, size_t count)
@@ -1502,13 +1513,12 @@ being registered.
 */
 static void COM_CheckRegistered (void)
 {
-	int		h;
 	unsigned short	check[128];
-	int		i;
+	size_t		i;
 
-	COM_OpenFile("gfx/pop.lmp", &h, NULL);
+	qfshandle_t* h = QFS_OpenFile("gfx/pop.lmp", NULL);
 
-	if (h == -1)
+	if (h == NULL)
 	{
 		Cvar_SetROM ("registered", "0");
 		Con_Printf ("Playing shareware version.\n");
@@ -1521,9 +1531,9 @@ static void COM_CheckRegistered (void)
 		return;
 	}
 
-	i = Sys_FileRead (h, check, sizeof(check));
-	COM_CloseFile (h);
-	if (i != (int) sizeof(check))
+	i = QFS_ReadFile (h, check, sizeof(check));
+	QFS_CloseFile (h);
+	if (i != sizeof(check))
 		goto corrupt;
 
 	for (i = 0; i < 128; i++)
@@ -1671,37 +1681,16 @@ QUAKE FILESYSTEM
 =============================================================================
 */
 
-THREAD_LOCAL qfileofs_t com_filesize;
-
-
-//
-// on-disk pakfile
-//
-typedef struct
-{
-	char	name[56];
-	int		filepos, filelen;
-} dpackfile_t;
-
-typedef struct
-{
-	char	id[4];
-	int		dirofs;
-	int		dirlen;
-} dpackheader_t;
-
-#define MAX_FILES_IN_PACK	2048
-
 char	com_gamenames[1024];	//eg: "hipnotic;quoth;warp" ... no id1
 char	com_gamedir[MAX_OSPATH];
 char	com_basedirs[MAX_BASEDIRS][MAX_OSPATH];
 int		com_numbasedirs;
 char	com_nightdivedir[MAX_OSPATH];
 char	com_userprefdir[MAX_OSPATH];
-THREAD_LOCAL int	file_from_pak;		// ZOID: global indicating that file came from a pak
 
 searchpath_t	*com_searchpaths;
 searchpath_t	*com_base_searchpaths;
+
 
 /*
 ============
@@ -1715,9 +1704,10 @@ static void COM_Path_f (void)
 	Con_Printf ("Current search path:\n");
 	for (s = com_searchpaths; s; s = s->next)
 	{
-		if (s->pack)
+		const char* pack_filename = QFS_PackInfoName (s->pack);
+		if (pack_filename)
 		{
-			Con_Printf ("%s (%i files)\n", s->pack->filename, s->pack->numfiles);
+			Con_Printf ("%s (%i files)\n", pack_filename, QFS_PackInfoNumFiles (s->pack));
 		}
 		else
 			Con_Printf ("%s\n", s->filename);
@@ -1733,21 +1723,22 @@ The filename will be prefixed by the current game directory
 */
 void COM_WriteFile (const char *filename, const void *data, int len)
 {
-	int		handle;
+	FILE*	handle;
 	char	name[MAX_OSPATH];
 
 	q_snprintf (name, sizeof(name), "%s/%s", com_gamedir, filename);
 
-	handle = Sys_FileOpenWrite (name);
-	if (handle == -1)
+	handle = Sys_fopen (name, "wb");
+	if (!handle)
 	{
 		Sys_Printf ("COM_WriteFile: failed on %s\n", name);
 		return;
 	}
 
 	Sys_Printf ("COM_WriteFile: %s\n", name);
-	Sys_FileWrite (handle, data, len);
-	Sys_FileClose (handle);
+	
+	fwrite (data, len, 1, handle);
+	fclose (handle);
 }
 
 /*
@@ -1865,279 +1856,6 @@ void COM_CreatePath (char *path)
 	}
 }
 
-/*
-================
-COM_filelength
-================
-*/
-qfileofs_t COM_filelength (FILE *f)
-{
-	qfileofs_t	pos, end;
-
-	pos = Sys_ftell (f);
-	Sys_fseek (f, 0, SEEK_END);
-	end = Sys_ftell (f);
-	Sys_fseek (f, pos, SEEK_SET);
-
-	return end;
-}
-
-/*
-===========
-COM_FindFile
-
-Finds the file in the search path.
-Sets com_filesize and one of handle or file
-If neither of file or handle is set, this
-can be used for detecting a file's presence.
-===========
-*/
-static int COM_FindFile (const char *filename, int *handle, FILE **file,
-							unsigned int *path_id)
-{
-	searchpath_t	*search;
-	char		netpath[MAX_OSPATH];
-	pack_t		*pak;
-	int			i;
-
-	if (file && handle)
-		Sys_Error ("COM_FindFile: both handle and file set");
-
-	file_from_pak = 0;
-
-//
-// search through the path, one element at a time
-//
-	for (search = com_searchpaths; search; search = search->next)
-	{
-		if (search->pack)	/* look through all the pak file elements */
-		{
-			pak = search->pack;
-			for (i = 0; i < pak->numfiles; i++)
-			{
-				if (strcmp(pak->files[i].name, filename) != 0)
-					continue;
-				// found it!
-				com_filesize = pak->files[i].filelen;
-				file_from_pak = 1;
-				if (path_id)
-					*path_id = search->path_id;
-				if (handle)
-				{
-					*handle = pak->handle;
-					Sys_FileSeek (pak->handle, pak->files[i].filepos);
-					return com_filesize;
-				}
-				else if (file)
-				{ /* open a new file on the pakfile */
-					*file = Sys_fopen (pak->filename, "rb");
-					if (*file)
-						fseek (*file, pak->files[i].filepos, SEEK_SET);
-					return com_filesize;
-				}
-				else /* for COM_FileExists() */
-				{
-					return com_filesize;
-				}
-			}
-		}
-		else	/* check a file in the directory tree */
-		{
-			if (!registered.value)
-			{ /* if not a registered version, don't ever go beyond base */
-				if ( strchr (filename, '/') || strchr (filename,'\\'))
-					continue;
-			}
-
-			q_snprintf (netpath, sizeof(netpath), "%s/%s",search->filename, filename);
-			if (! (Sys_FileType(netpath) & FS_ENT_FILE))
-				continue;
-
-			if (path_id)
-				*path_id = search->path_id;
-			if (handle)
-			{
-				com_filesize = Sys_FileOpenRead (netpath, &i);
-				*handle = i;
-				return com_filesize;
-			}
-			else if (file)
-			{
-				*file = Sys_fopen (netpath, "rb");
-				com_filesize = (*file == NULL) ? -1 : COM_filelength (*file);
-				return com_filesize;
-			}
-			else
-			{
-				return 0; /* dummy valid value for COM_FileExists() */
-			}
-		}
-	}
-
-	if (developer.value)
-	{
-		const char *ext = COM_FileGetExtension (filename);
-
-		if (strcmp(ext, "pcx") != 0 &&
-			strcmp(ext, "tga") != 0 &&
-			strcmp(ext, "png") != 0 &&
-			strcmp(ext, "jpg") != 0 &&
-			strcmp(ext, "lmp") != 0 &&
-			// music formats
-			strcmp (ext, "ogg") != 0 &&
-			strcmp (ext, "opus") != 0 &&
-			strcmp (ext, "flac") != 0 &&
-			strcmp (ext, "wav") != 0 &&
-			strcmp (ext, "it") != 0 &&
-			strcmp (ext, "s3m") != 0 &&
-			strcmp (ext, "xm") != 0 &&
-			strcmp (ext, "mod") != 0 &&
-			strcmp (ext, "umx") != 0 &&
-			// alternate model formats
-			strcmp(ext, "md5mesh") != 0 &&
-			strcmp (ext, "md3") != 0 &&
-			strcmp (ext, "skin") != 0 &&
-			// optional map files
-			strcmp(ext, "lit") != 0 &&
-			strcmp(ext, "vis") != 0 &&
-			strcmp(ext, "ent") != 0)
-			Con_DPrintf ("FindFile: can't find %s\n", filename);
-		else
-			Con_DPrintf2 ("FindFile: can't find %s\n", filename);
-	}
-
-	if (handle)
-		*handle = -1;
-	if (file)
-		*file = NULL;
-	com_filesize = -1;
-	return com_filesize;
-}
-
-
-/*
-===========
-COM_FileExists
-
-Returns whether the file is found in the quake filesystem.
-===========
-*/
-qboolean COM_FileExists (const char *filename, unsigned int *path_id)
-{
-	int ret = COM_FindFile (filename, NULL, NULL, path_id);
-	return (ret == -1) ? false : true;
-}
-
-/*
-===========
-COM_OpenFile
-
-filename never has a leading slash, but may contain directory walks
-returns a handle and a length
-it may actually be inside a pak file
-===========
-*/
-int COM_OpenFile (const char *filename, int *handle, unsigned int *path_id)
-{
-	return COM_FindFile (filename, handle, NULL, path_id);
-}
-
-/*
-===========
-COM_FOpenFile
-
-If the requested file is inside a packfile, a new FILE * will be opened
-into the file.
-===========
-*/
-int COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id)
-{
-	return COM_FindFile (filename, NULL, file, path_id);
-}
-
-/*
-============
-COM_CloseFile
-
-If it is a pak file handle, don't really close it
-============
-*/
-void COM_CloseFile (int h)
-{
-	searchpath_t	*s;
-
-	for (s = com_searchpaths; s; s = s->next)
-		if (s->pack && s->pack->handle == h)
-			return;
-
-	Sys_FileClose (h);
-}
-
-
-/*
-============
-COM_LoadFile
-
-Filename are reletive to the quake directory.
-Allways appends a 0 byte.
-============
-*/
-#define	LOADFILE_HUNK		0
-#define	LOADFILE_MALLOC		1
-
-byte *COM_LoadFile (const char *path, int usehunk, unsigned int *path_id)
-{
-	int		h;
-	byte	*buf;
-	char	base[32];
-	int	len, nread;
-
-	buf = NULL;	// quiet compiler warning
-
-// look for it in the filesystem or pack files
-	len = COM_OpenFile (path, &h, path_id);
-	if (h == -1)
-		return NULL;
-
-// extract the filename base name for hunk tag
-	COM_FileBase (path, base, sizeof(base));
-
-	switch (usehunk)
-	{
-	case LOADFILE_HUNK:
-		buf = (byte *) Hunk_AllocNameNoFill (len+1, base);
-		break;
-	case LOADFILE_MALLOC:
-		buf = (byte *) malloc (len+1);
-		break;
-	default:
-		Sys_Error ("COM_LoadFile: bad usehunk");
-	}
-
-	if (!buf)
-		Sys_Error ("COM_LoadFile: not enough space for %s", path);
-
-	((byte *)buf)[len] = 0;
-
-	nread = Sys_FileRead (h, buf, len);
-	COM_CloseFile (h);
-	if (nread != len)
-		Sys_Error ("COM_LoadFile: Error reading %s", path);
-
-	return buf;
-}
-
-byte *COM_LoadHunkFile (const char *path, unsigned int *path_id)
-{
-	return COM_LoadFile (path, LOADFILE_HUNK, path_id);
-}
-
-// returns malloc'd memory
-byte *COM_LoadMallocFile (const char *path, unsigned int *path_id)
-{
-	return COM_LoadFile (path, LOADFILE_MALLOC, path_id);
-}
-
 byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 {
 	FILE	*f;
@@ -2152,7 +1870,7 @@ byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 	if (f == NULL)
 		return NULL;
 
-	len = COM_filelength (f);
+	len = (long)Sys_filelength (f);
 	if (len < 0)
 	{
 		fclose (f);
@@ -2246,87 +1964,6 @@ const char *COM_ParseStringNewline(const char *buffer)
 	return buffer + i;
 }
 
-/*
-=================
-COM_LoadPackFile -- johnfitz -- modified based on topaz's tutorial
-
-Takes an explicit (not game tree related) path to a pak file.
-
-Loads the header and directory, adding the files at the beginning
-of the list so they override previous pack files.
-=================
-*/
-static pack_t *COM_LoadPackFile (const char *packfile)
-{
-	dpackheader_t	header;
-	int		i;
-	packfile_t	*newfiles;
-	int		numpackfiles;
-	pack_t		*pack;
-	int		packhandle;
-	dpackfile_t	info[MAX_FILES_IN_PACK];
-
-	if (Sys_FileOpenRead (packfile, &packhandle) == -1)
-		return NULL;
-
-	if (Sys_FileRead(packhandle, &header, sizeof(header)) != (int) sizeof(header) ||
-	    header.id[0] != 'P' || header.id[1] != 'A' || header.id[2] != 'C' || header.id[3] != 'K')
-		Sys_Error ("%s is not a packfile", packfile);
-
-	header.dirofs = LittleLong (header.dirofs);
-	header.dirlen = LittleLong (header.dirlen);
-
-	numpackfiles = header.dirlen / sizeof(dpackfile_t);
-
-	if (header.dirlen < 0 || header.dirofs < 0)
-	{
-		Sys_Error ("Invalid packfile %s (dirlen: %i, dirofs: %i)",
-					packfile, header.dirlen, header.dirofs);
-	}
-	if (!numpackfiles)
-	{
-		Sys_Printf ("WARNING: %s has no files, ignored\n", packfile);
-		Sys_FileClose (packhandle);
-		return NULL;
-	}
-	if (numpackfiles > MAX_FILES_IN_PACK)
-		Sys_Error ("%s has %i files", packfile, numpackfiles);
-
-	if (numpackfiles != PAK0_COUNT)
-		com_modified = true;	// not the original file
-
-	newfiles = (packfile_t *) Z_Malloc(numpackfiles * sizeof(packfile_t));
-
-	Sys_FileSeek (packhandle, header.dirofs);
-	if (Sys_FileRead(packhandle, info, header.dirlen) != header.dirlen)
-		Sys_Error ("Error reading %s", packfile);
-
-	// crc the directory to check for modifications
-	if (!com_modified)
-	{
-		unsigned short	crc = CRC_Block (info, header.dirlen);
-		if (crc != PAK0_CRC_V106 && crc != PAK0_CRC_V101 && crc != PAK0_CRC_V100)
-			com_modified = true;
-	}
-
-	// parse the directory
-	for (i = 0; i < numpackfiles; i++)
-	{
-		q_strlcpy (newfiles[i].name, info[i].name, sizeof(newfiles[i].name));
-		newfiles[i].filepos = LittleLong(info[i].filepos);
-		newfiles[i].filelen = LittleLong(info[i].filelen);
-	}
-
-	pack = (pack_t *) Z_Malloc (sizeof (pack_t));
-	q_strlcpy (pack->filename, packfile, sizeof(pack->filename));
-	pack->handle = packhandle;
-	pack->numfiles = numpackfiles;
-	pack->files = newfiles;
-
-	//Sys_Printf ("Added packfile %s (%i files)\n", packfile, numpackfiles);
-	return pack;
-}
-
 const char *COM_GetGameNames(qboolean full)
 {
 	if (full)
@@ -2337,8 +1974,60 @@ const char *COM_GetGameNames(qboolean full)
 			return GAMENAME;
 	}
 	return com_gamenames;
-//	return COM_SkipPath(com_gamedir);
 }
+
+/*
+=================
+COM_PackNameCompare
+
+Case insensitive compare function
+=================
+*/
+static int COM_PackNameCompare (const void* f1, const void* f2)
+{
+	return q_strcasecmp (((const findfile_t*)f1)->name, ((const findfile_t*)f2)->name);
+}
+
+/*
+=================
+COM_FindWildPacks
+
+Finds all pack files in a directory that are outside the pakN series.
+Only .pk3 files that have fully ASCII names
+
+Returns a dynamic array of findfile_t that should be freed with VEC_FREE
+=================
+*/
+static findfile_t* COM_FindWildPacks (const char *dir)
+{
+	findfile_t *p, *pfiles = NULL;
+	for (p = Sys_FindFirst (dir, NULL); p; p = Sys_FindNext (p))
+	{
+		const char *ext = COM_FileGetExtension (p->name);
+		if ((p->attribs & FA_DIRECTORY) || !q_strascii (p->name) || q_strcasecmp (ext, "pk3") != 0)
+			continue;
+
+		if (strlen (p->name) >= 8 && q_strncasecmp (p->name, "pak", 3) == 0)
+		{
+			const char *paknum, *numend;
+			int ndigits = 0;
+			numend = ext - 1;
+
+			for (paknum = &p->name[3]; paknum < numend; ++paknum)
+				ndigits += q_isdigit (*paknum);
+			
+			if (ndigits >= (int)(numend - &p->name[3]))
+				continue;
+		}
+
+		VEC_PUSH (pfiles, *p);
+	}
+
+	if (pfiles)
+		qsort (pfiles, VEC_SIZE (pfiles), sizeof(findfile_t), &COM_PackNameCompare);
+
+	return pfiles;
+} 
 
 /*
 =================
@@ -2349,19 +2038,19 @@ static void COM_AddEnginePak (void)
 {
 	int			i;
 	char		pakfile[MAX_OSPATH];
-	pack_t		*pak = NULL;
+	int			pak = 0;
 	qboolean	modified = com_modified;
 
 	if (host_parms->exedir)
 	{
 		q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, host_parms->exedir);
-		pak = COM_LoadPackFile (pakfile);
+		pak = QFS_LoadPackFile (pakfile);
 	}
 
 	if (!pak)
 	{
 		q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, host_parms->basedir);
-		pak = COM_LoadPackFile (pakfile);
+		pak = QFS_LoadPackFile (pakfile);
 	}
 
 	if (!pak)
@@ -2369,7 +2058,7 @@ static void COM_AddEnginePak (void)
 		for (i = 0; i < com_numbasedirs; i++)
 		{
 			q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, com_basedirs[i]);
-			pak = COM_LoadPackFile (pakfile);
+			pak = QFS_LoadPackFile (pakfile);
 			if (pak)
 				break;
 		}
@@ -2395,11 +2084,13 @@ COM_AddGameDirectory -- johnfitz -- modified based on topaz's tutorial
 void COM_AddGameDirectory (const char *dir)
 {
 	const char *base;
-	int i, j;
+	int i, j, k;
 	unsigned int path_id;
 	searchpath_t *search;
-	pack_t *pak;
+	findfile_t* wildpacks;
+	int pak = 0;
 	char pakfile[MAX_OSPATH];
+	static const char* pkext[2] = { "pak", "pk3" };
 
 	if (*com_gamenames)
 		q_strlcat(com_gamenames, ";", sizeof(com_gamenames));
@@ -2437,11 +2128,18 @@ void COM_AddGameDirectory (const char *dir)
 		search->next = com_searchpaths;
 		com_searchpaths = search;
 
-		// add any pak files in the format pak0.pak pak1.pak, ...
+		// add any pak files (or pk3 files) in the format pak0.pak pak1.pak, ...
+		// pak files and pk3 files can not have the same number, if it exists
+		// with both extensions, the pak file will be used and the pk3 file ignored
 		for (i = 0; ; i++)
 		{
-			q_snprintf (pakfile, sizeof(pakfile), "%s/pak%i.pak", com_gamedir, i);
-			pak = COM_LoadPackFile (pakfile);
+			for (k = 0; k < countof(pkext); ++k)
+			{
+				q_snprintf (pakfile, sizeof(pakfile), "%s/pak%i.%s", com_gamedir, i, pkext[k]);
+				pak = QFS_LoadPackFile (pakfile);
+				if (pak)
+					break;
+			}
 			if (!pak)
 				break;
 
@@ -2455,6 +2153,26 @@ void COM_AddGameDirectory (const char *dir)
 			if (i == 0 && j == 0 && path_id == 1u && !fitzmode)
 				COM_AddEnginePak ();
 		}
+
+		// Add any "wild" pk3 packs outside of the pakN scheme
+		wildpacks = COM_FindWildPacks (com_gamedir);
+		if (wildpacks)
+		{
+			for (i = 0; i < (int)VEC_SIZE (wildpacks); ++i)
+			{
+				q_snprintf (pakfile, sizeof(pakfile), "%s/%s", com_gamedir, wildpacks[i].name);
+				pak = QFS_LoadPackFile (pakfile);
+				if (pak)
+				{
+					search = (searchpath_t *) Z_Malloc (sizeof(searchpath_t));
+					search->path_id = path_id;
+					search->pack = pak;
+					search->next = com_searchpaths;
+					com_searchpaths = search;
+				}
+			}
+			VEC_FREE (wildpacks);
+		}
 	}
 }
 
@@ -2466,11 +2184,8 @@ void COM_ResetGameDirectories(const char *newgamedirs)
 	while (com_searchpaths != com_base_searchpaths)
 	{
 		if (com_searchpaths->pack)
-		{
-			Sys_FileClose (com_searchpaths->pack->handle);
-			Z_Free (com_searchpaths->pack->files);
-			Z_Free (com_searchpaths->pack);
-		}
+			QFS_FreePack(com_searchpaths->pack);
+
 		search = com_searchpaths->next;
 		Z_Free (com_searchpaths);
 		com_searchpaths = search;
@@ -3335,176 +3050,6 @@ void COM_InitFilesystem (void) //johnfitz -- modified based on topaz's tutorial
 	}
 
 	COM_CheckRegistered ();
-}
-
-
-/* The following FS_*() stdio replacements are necessary if one is
- * to perform non-sequential reads on files reopened on pak files
- * because we need the bookkeeping about file start/end positions.
- * Allocating and filling in the fshandle_t structure is the users'
- * responsibility when the file is initially opened. */
-
-size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh)
-{
-	long byte_size;
-	long bytes_read;
-	size_t nmemb_read;
-
-	if (!fh) {
-		errno = EBADF;
-		return 0;
-	}
-	if (!ptr) {
-		errno = EFAULT;
-		return 0;
-	}
-	if (!size || !nmemb) {	/* no error, just zero bytes wanted */
-		errno = 0;
-		return 0;
-	}
-
-	byte_size = nmemb * size;
-	if (byte_size > fh->length - fh->pos)	/* just read to end */
-		byte_size = fh->length - fh->pos;
-	bytes_read = fread(ptr, 1, byte_size, fh->file);
-	fh->pos += bytes_read;
-
-	/* fread() must return the number of elements read,
-	 * not the total number of bytes. */
-	nmemb_read = bytes_read / size;
-	/* even if the last member is only read partially
-	 * it is counted as a whole in the return value. */
-	if (bytes_read % size)
-		nmemb_read++;
-
-	return nmemb_read;
-}
-
-int FS_fseek(fshandle_t *fh, long offset, int whence)
-{
-/* I don't care about 64 bit off_t or fseeko() here.
- * the quake/hexen2 file system is 32 bits, anyway. */
-	int ret;
-
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-
-	/* the relative file position shouldn't be smaller
-	 * than zero or bigger than the filesize. */
-	switch (whence)
-	{
-	case SEEK_SET:
-		break;
-	case SEEK_CUR:
-		offset += fh->pos;
-		break;
-	case SEEK_END:
-		offset = fh->length + offset;
-		break;
-	default:
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (offset < 0) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (offset > fh->length)	/* just seek to end */
-		offset = fh->length;
-
-	ret = fseek(fh->file, fh->start + offset, SEEK_SET);
-	if (ret < 0)
-		return ret;
-
-	fh->pos = offset;
-	return 0;
-}
-
-int FS_fclose(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fclose(fh->file);
-}
-
-long FS_ftell(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fh->pos;
-}
-
-void FS_rewind(fshandle_t *fh)
-{
-	if (!fh) return;
-	clearerr(fh->file);
-	fseek(fh->file, fh->start, SEEK_SET);
-	fh->pos = 0;
-}
-
-int FS_feof(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	if (fh->pos >= fh->length)
-		return -1;
-	return 0;
-}
-
-int FS_ferror(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return ferror(fh->file);
-}
-
-int FS_fgetc(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return EOF;
-	}
-	if (fh->pos >= fh->length)
-		return EOF;
-	fh->pos += 1;
-	return fgetc(fh->file);
-}
-
-char *FS_fgets(char *s, int size, fshandle_t *fh)
-{
-	char *ret;
-
-	if (FS_feof(fh))
-		return NULL;
-
-	if (size > (fh->length - fh->pos) + 1)
-		size = (fh->length - fh->pos) + 1;
-
-	ret = fgets(s, size, fh->file);
-	fh->pos = ftell(fh->file) - fh->start;
-
-	return ret;
-}
-
-long FS_filelength (fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fh->length;
 }
 
 /*
@@ -4467,4 +4012,73 @@ size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src)
 	dst[i++] = '\0';
 
 	return i;
+}
+
+/*
+==================
+UTF8_FromIBM437
+
+Transliterates a string from IBM code page 437 to UTF-8 encoding.
+cp437 was often used in MSDOS and its ghost lives on in some file formats.
+
+Returns the number of written characters (including the NUL terminator)
+if a valid output buffer is provided (dst is non-NULL, maxbytes > 0),
+or the total amount of space necessary to encode the entire src string
+if dst is NULL and maxbytes is 0.
+
+==================
+*/
+size_t UTF8_FromIBM437 (char* dst, size_t maxbytes, const char* src)
+{
+	const char *p;
+	char *d;
+	static const uint16_t ibm437_high[0x80] =	/*Code points from 0x80-0xff, below it's just ASCII*/
+	{
+		0x00c7, 0x00fc, 0x00e9, 0x00e2, 0x00e4, 0x00e0, 0x00e5, 0x00e7, 0x00ea, 0x00eb, 0x00e8, 0x00ef, 0x00ee, 0x00ec, 0x00c4, 0x00c5,
+		0x00c9, 0x00e6, 0x00c6, 0x00f4, 0x00f6, 0x00f2, 0x00fb, 0x00f9, 0x00ff, 0x00d6, 0x00dc, 0x00a2, 0x00a3, 0x00a5, 0x20a7, 0x0192,
+		0x00e1, 0x00ed, 0x00f3, 0x00fa, 0x00f1, 0x00d1, 0x00aa, 0x00ba, 0x00bf, 0x2310, 0x00ac, 0x00bd, 0x00bc, 0x00a1, 0x00ab, 0x00bb,
+		0x2591, 0x2592, 0x2593, 0x2502, 0x2524, 0x2561, 0x2562, 0x2556, 0x2555, 0x2563, 0x2551, 0x2557, 0x255d, 0x255c, 0x255b, 0x2510,
+		0x2514, 0x2534, 0x252c, 0x251c, 0x2500, 0x253c, 0x255e, 0x255f, 0x255a, 0x2554, 0x2569, 0x2566, 0x2560, 0x2550, 0x256c, 0x2567,
+		0x2568, 0x2564, 0x2565, 0x2559, 0x2558, 0x2552, 0x2553, 0x256b, 0x256a, 0x2518, 0x250c, 0x2588, 0x2584, 0x258c, 0x2590, 0x2580,
+		0x03b1, 0x00df, 0x0393, 0x03c0, 0x03a3, 0x03c3, 0x00b5, 0x03c4, 0x03a6, 0x0398, 0x03a9, 0x03b4, 0x221e, 0x03c6, 0x03b5, 0x2229,
+		0x2261, 0x00b1, 0x2265, 0x2264, 0x2320, 0x2321, 0x00f7, 0x2248, 0x00b0, 0x2219, 0x00b7, 0x221a, 0x207f, 0x00b2, 0x25a0, 0x00a0
+	};
+
+	if (maxbytes == 0)
+	{
+		size_t cnt = 1;
+		if (dst != NULL)
+			return 0;
+
+		for (p = src; *p; ++p)
+		{
+			byte ch = (byte)*p;
+			if (ch & 0x80)
+				cnt += UTF8_CodePointLength (ibm437_high[ch & 0x7f]);
+			else
+				cnt += 1;
+		}
+		return cnt;
+	}
+
+	for (p = src, d = dst; *p && maxbytes > 1; ++p)
+	{
+		byte ch = (byte)*p;
+		if (ch & 0x80)
+		{
+			size_t n = UTF8_WriteCodePoint (d, maxbytes, ibm437_high[ch & 0x7f]);
+			if (n >= maxbytes)
+				break;
+			d += n;
+			maxbytes -= n;
+		}
+		else
+		{
+			*d++ = *p;
+			maxbytes -= 1;
+		}
+	}
+
+	*d++ = '\0';
+	return (size_t)(d - dst);
 }

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -30,6 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <errno.h>
 #include "miniz.h"
 #include "unicode_translit.h"
+#include "filesys.h"
 
 static const char	*largv[MAX_NUM_ARGVS + 1];
 static char	argvdummy[] = " ";
@@ -408,6 +409,16 @@ int q_snprintf (char *str, size_t size, const char *format, ...)
 	va_end (argptr);
 
 	return ret;
+}
+
+qboolean q_strascii (const char* str)
+{
+	while (*str++)
+	{
+		if ((byte)*str > 0x7f)
+			return false;
+	}
+	return true;
 }
 
 void Q_memset (void *dest, int fill, size_t count)
@@ -1605,13 +1616,12 @@ being registered.
 */
 static void COM_CheckRegistered (void)
 {
-	int		h;
 	unsigned short	check[128];
-	int		i;
+	size_t		i;
 
-	COM_OpenFile("gfx/pop.lmp", &h, NULL);
+	qfshandle_t* h = QFS_OpenFile("gfx/pop.lmp", NULL);
 
-	if (h == -1)
+	if (h == NULL)
 	{
 		Cvar_SetROM ("registered", "0");
 		Con_Printf ("Playing shareware version.\n");
@@ -1624,9 +1634,9 @@ static void COM_CheckRegistered (void)
 		return;
 	}
 
-	i = Sys_FileRead (h, check, sizeof(check));
-	COM_CloseFile (h);
-	if (i != (int) sizeof(check))
+	i = QFS_ReadFile (h, check, sizeof(check));
+	QFS_CloseFile (h);
+	if (i != sizeof(check))
 		goto corrupt;
 
 	for (i = 0; i < 128; i++)
@@ -1772,37 +1782,16 @@ QUAKE FILESYSTEM
 =============================================================================
 */
 
-THREAD_LOCAL qfileofs_t com_filesize;
-
-
-//
-// on-disk pakfile
-//
-typedef struct
-{
-	char	name[56];
-	int		filepos, filelen;
-} dpackfile_t;
-
-typedef struct
-{
-	char	id[4];
-	int		dirofs;
-	int		dirlen;
-} dpackheader_t;
-
-#define MAX_FILES_IN_PACK	2048
-
 char	com_gamenames[1024];	//eg: "hipnotic;quoth;warp" ... no id1
 char	com_gamedir[MAX_OSPATH];
 char	com_basedirs[MAX_BASEDIRS][MAX_OSPATH];
 int		com_numbasedirs;
 char	com_nightdivedir[MAX_OSPATH];
 char	com_userprefdir[MAX_OSPATH];
-THREAD_LOCAL int	file_from_pak;		// ZOID: global indicating that file came from a pak
 
 searchpath_t	*com_searchpaths;
 searchpath_t	*com_base_searchpaths;
+
 
 /*
 ============
@@ -1816,9 +1805,10 @@ static void COM_Path_f (void)
 	Con_Printf ("Current search path:\n");
 	for (s = com_searchpaths; s; s = s->next)
 	{
-		if (s->pack)
+		const char* pack_filename = QFS_PackInfoName (s->pack);
+		if (pack_filename)
 		{
-			Con_Printf ("%s (%i files)\n", s->pack->filename, s->pack->numfiles);
+			Con_Printf ("%s (%i files)\n", pack_filename, QFS_PackInfoNumFiles (s->pack));
 		}
 		else
 			Con_Printf ("%s\n", s->filename);
@@ -1834,21 +1824,22 @@ The filename will be prefixed by the current game directory
 */
 void COM_WriteFile (const char *filename, const void *data, int len)
 {
-	int		handle;
+	FILE*	handle;
 	char	name[MAX_OSPATH];
 
 	q_snprintf (name, sizeof(name), "%s/%s", com_gamedir, filename);
 
-	handle = Sys_FileOpenWrite (name);
-	if (handle == -1)
+	handle = Sys_fopen (name, "wb");
+	if (!handle)
 	{
 		Sys_Printf ("COM_WriteFile: failed on %s\n", name);
 		return;
 	}
 
 	Sys_Printf ("COM_WriteFile: %s\n", name);
-	Sys_FileWrite (handle, data, len);
-	Sys_FileClose (handle);
+	
+	fwrite (data, len, 1, handle);
+	fclose (handle);
 }
 
 /*
@@ -1966,279 +1957,6 @@ void COM_CreatePath (char *path)
 	}
 }
 
-/*
-================
-COM_filelength
-================
-*/
-qfileofs_t COM_filelength (FILE *f)
-{
-	qfileofs_t	pos, end;
-
-	pos = Sys_ftell (f);
-	Sys_fseek (f, 0, SEEK_END);
-	end = Sys_ftell (f);
-	Sys_fseek (f, pos, SEEK_SET);
-
-	return end;
-}
-
-/*
-===========
-COM_FindFile
-
-Finds the file in the search path.
-Sets com_filesize and one of handle or file
-If neither of file or handle is set, this
-can be used for detecting a file's presence.
-===========
-*/
-static int COM_FindFile (const char *filename, int *handle, FILE **file,
-							unsigned int *path_id)
-{
-	searchpath_t	*search;
-	char		netpath[MAX_OSPATH];
-	pack_t		*pak;
-	int			i;
-
-	if (file && handle)
-		Sys_Error ("COM_FindFile: both handle and file set");
-
-	file_from_pak = 0;
-
-//
-// search through the path, one element at a time
-//
-	for (search = com_searchpaths; search; search = search->next)
-	{
-		if (search->pack)	/* look through all the pak file elements */
-		{
-			pak = search->pack;
-			for (i = 0; i < pak->numfiles; i++)
-			{
-				if (strcmp(pak->files[i].name, filename) != 0)
-					continue;
-				// found it!
-				com_filesize = pak->files[i].filelen;
-				file_from_pak = 1;
-				if (path_id)
-					*path_id = search->path_id;
-				if (handle)
-				{
-					*handle = pak->handle;
-					Sys_FileSeek (pak->handle, pak->files[i].filepos);
-					return com_filesize;
-				}
-				else if (file)
-				{ /* open a new file on the pakfile */
-					*file = Sys_fopen (pak->filename, "rb");
-					if (*file)
-						fseek (*file, pak->files[i].filepos, SEEK_SET);
-					return com_filesize;
-				}
-				else /* for COM_FileExists() */
-				{
-					return com_filesize;
-				}
-			}
-		}
-		else	/* check a file in the directory tree */
-		{
-			if (!registered.value)
-			{ /* if not a registered version, don't ever go beyond base */
-				if ( strchr (filename, '/') || strchr (filename,'\\'))
-					continue;
-			}
-
-			q_snprintf (netpath, sizeof(netpath), "%s/%s",search->filename, filename);
-			if (! (Sys_FileType(netpath) & FS_ENT_FILE))
-				continue;
-
-			if (path_id)
-				*path_id = search->path_id;
-			if (handle)
-			{
-				com_filesize = Sys_FileOpenRead (netpath, &i);
-				*handle = i;
-				return com_filesize;
-			}
-			else if (file)
-			{
-				*file = Sys_fopen (netpath, "rb");
-				com_filesize = (*file == NULL) ? -1 : COM_filelength (*file);
-				return com_filesize;
-			}
-			else
-			{
-				return 0; /* dummy valid value for COM_FileExists() */
-			}
-		}
-	}
-
-	if (developer.value)
-	{
-		const char *ext = COM_FileGetExtension (filename);
-
-		if (strcmp(ext, "pcx") != 0 &&
-			strcmp(ext, "tga") != 0 &&
-			strcmp(ext, "png") != 0 &&
-			strcmp(ext, "jpg") != 0 &&
-			strcmp(ext, "lmp") != 0 &&
-			// music formats
-			strcmp (ext, "ogg") != 0 &&
-			strcmp (ext, "opus") != 0 &&
-			strcmp (ext, "flac") != 0 &&
-			strcmp (ext, "wav") != 0 &&
-			strcmp (ext, "it") != 0 &&
-			strcmp (ext, "s3m") != 0 &&
-			strcmp (ext, "xm") != 0 &&
-			strcmp (ext, "mod") != 0 &&
-			strcmp (ext, "umx") != 0 &&
-			// alternate model formats
-			strcmp(ext, "md5mesh") != 0 &&
-			strcmp (ext, "md3") != 0 &&
-			strcmp (ext, "skin") != 0 &&
-			// optional map files
-			strcmp(ext, "lit") != 0 &&
-			strcmp(ext, "vis") != 0 &&
-			strcmp(ext, "ent") != 0)
-			Con_DPrintf ("FindFile: can't find %s\n", filename);
-		else
-			Con_DPrintf2 ("FindFile: can't find %s\n", filename);
-	}
-
-	if (handle)
-		*handle = -1;
-	if (file)
-		*file = NULL;
-	com_filesize = -1;
-	return com_filesize;
-}
-
-
-/*
-===========
-COM_FileExists
-
-Returns whether the file is found in the quake filesystem.
-===========
-*/
-qboolean COM_FileExists (const char *filename, unsigned int *path_id)
-{
-	int ret = COM_FindFile (filename, NULL, NULL, path_id);
-	return (ret == -1) ? false : true;
-}
-
-/*
-===========
-COM_OpenFile
-
-filename never has a leading slash, but may contain directory walks
-returns a handle and a length
-it may actually be inside a pak file
-===========
-*/
-int COM_OpenFile (const char *filename, int *handle, unsigned int *path_id)
-{
-	return COM_FindFile (filename, handle, NULL, path_id);
-}
-
-/*
-===========
-COM_FOpenFile
-
-If the requested file is inside a packfile, a new FILE * will be opened
-into the file.
-===========
-*/
-int COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id)
-{
-	return COM_FindFile (filename, NULL, file, path_id);
-}
-
-/*
-============
-COM_CloseFile
-
-If it is a pak file handle, don't really close it
-============
-*/
-void COM_CloseFile (int h)
-{
-	searchpath_t	*s;
-
-	for (s = com_searchpaths; s; s = s->next)
-		if (s->pack && s->pack->handle == h)
-			return;
-
-	Sys_FileClose (h);
-}
-
-
-/*
-============
-COM_LoadFile
-
-Filename are reletive to the quake directory.
-Allways appends a 0 byte.
-============
-*/
-#define	LOADFILE_HUNK		0
-#define	LOADFILE_MALLOC		1
-
-byte *COM_LoadFile (const char *path, int usehunk, unsigned int *path_id)
-{
-	int		h;
-	byte	*buf;
-	char	base[32];
-	int	len, nread;
-
-	buf = NULL;	// quiet compiler warning
-
-// look for it in the filesystem or pack files
-	len = COM_OpenFile (path, &h, path_id);
-	if (h == -1)
-		return NULL;
-
-// extract the filename base name for hunk tag
-	COM_FileBase (path, base, sizeof(base));
-
-	switch (usehunk)
-	{
-	case LOADFILE_HUNK:
-		buf = (byte *) Hunk_AllocNameNoFill (len+1, base);
-		break;
-	case LOADFILE_MALLOC:
-		buf = (byte *) malloc (len+1);
-		break;
-	default:
-		Sys_Error ("COM_LoadFile: bad usehunk");
-	}
-
-	if (!buf)
-		Sys_Error ("COM_LoadFile: not enough space for %s", path);
-
-	((byte *)buf)[len] = 0;
-
-	nread = Sys_FileRead (h, buf, len);
-	COM_CloseFile (h);
-	if (nread != len)
-		Sys_Error ("COM_LoadFile: Error reading %s", path);
-
-	return buf;
-}
-
-byte *COM_LoadHunkFile (const char *path, unsigned int *path_id)
-{
-	return COM_LoadFile (path, LOADFILE_HUNK, path_id);
-}
-
-// returns malloc'd memory
-byte *COM_LoadMallocFile (const char *path, unsigned int *path_id)
-{
-	return COM_LoadFile (path, LOADFILE_MALLOC, path_id);
-}
-
 byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 {
 	FILE	*f;
@@ -2253,7 +1971,7 @@ byte *COM_LoadMallocFile_TextMode_OSPath (const char *path, long *len_out)
 	if (f == NULL)
 		return NULL;
 
-	len = COM_filelength (f);
+	len = (long)Sys_filelength (f);
 	if (len < 0)
 	{
 		fclose (f);
@@ -2347,87 +2065,6 @@ const char *COM_ParseStringNewline(const char *buffer)
 	return buffer + i;
 }
 
-/*
-=================
-COM_LoadPackFile -- johnfitz -- modified based on topaz's tutorial
-
-Takes an explicit (not game tree related) path to a pak file.
-
-Loads the header and directory, adding the files at the beginning
-of the list so they override previous pack files.
-=================
-*/
-static pack_t *COM_LoadPackFile (const char *packfile)
-{
-	dpackheader_t	header;
-	int		i;
-	packfile_t	*newfiles;
-	int		numpackfiles;
-	pack_t		*pack;
-	int		packhandle;
-	dpackfile_t	info[MAX_FILES_IN_PACK];
-
-	if (Sys_FileOpenRead (packfile, &packhandle) == -1)
-		return NULL;
-
-	if (Sys_FileRead(packhandle, &header, sizeof(header)) != (int) sizeof(header) ||
-	    header.id[0] != 'P' || header.id[1] != 'A' || header.id[2] != 'C' || header.id[3] != 'K')
-		Sys_Error ("%s is not a packfile", packfile);
-
-	header.dirofs = LittleLong (header.dirofs);
-	header.dirlen = LittleLong (header.dirlen);
-
-	numpackfiles = header.dirlen / sizeof(dpackfile_t);
-
-	if (header.dirlen < 0 || header.dirofs < 0)
-	{
-		Sys_Error ("Invalid packfile %s (dirlen: %i, dirofs: %i)",
-					packfile, header.dirlen, header.dirofs);
-	}
-	if (!numpackfiles)
-	{
-		Sys_Printf ("WARNING: %s has no files, ignored\n", packfile);
-		Sys_FileClose (packhandle);
-		return NULL;
-	}
-	if (numpackfiles > MAX_FILES_IN_PACK)
-		Sys_Error ("%s has %i files", packfile, numpackfiles);
-
-	if (numpackfiles != PAK0_COUNT)
-		com_modified = true;	// not the original file
-
-	newfiles = (packfile_t *) Z_Malloc(numpackfiles * sizeof(packfile_t));
-
-	Sys_FileSeek (packhandle, header.dirofs);
-	if (Sys_FileRead(packhandle, info, header.dirlen) != header.dirlen)
-		Sys_Error ("Error reading %s", packfile);
-
-	// crc the directory to check for modifications
-	if (!com_modified)
-	{
-		unsigned short	crc = CRC_Block (info, header.dirlen);
-		if (crc != PAK0_CRC_V106 && crc != PAK0_CRC_V101 && crc != PAK0_CRC_V100)
-			com_modified = true;
-	}
-
-	// parse the directory
-	for (i = 0; i < numpackfiles; i++)
-	{
-		q_strlcpy (newfiles[i].name, info[i].name, sizeof(newfiles[i].name));
-		newfiles[i].filepos = LittleLong(info[i].filepos);
-		newfiles[i].filelen = LittleLong(info[i].filelen);
-	}
-
-	pack = (pack_t *) Z_Malloc (sizeof (pack_t));
-	q_strlcpy (pack->filename, packfile, sizeof(pack->filename));
-	pack->handle = packhandle;
-	pack->numfiles = numpackfiles;
-	pack->files = newfiles;
-
-	//Sys_Printf ("Added packfile %s (%i files)\n", packfile, numpackfiles);
-	return pack;
-}
-
 const char *COM_GetGameNames(qboolean full)
 {
 	if (full)
@@ -2438,8 +2075,60 @@ const char *COM_GetGameNames(qboolean full)
 			return GAMENAME;
 	}
 	return com_gamenames;
-//	return COM_SkipPath(com_gamedir);
 }
+
+/*
+=================
+COM_PackNameCompare
+
+Case insensitive compare function
+=================
+*/
+static int COM_PackNameCompare (const void* f1, const void* f2)
+{
+	return q_strcasecmp (((const findfile_t*)f1)->name, ((const findfile_t*)f2)->name);
+}
+
+/*
+=================
+COM_FindWildPacks
+
+Finds all pack files in a directory that are outside the pakN series.
+Only .pk3 files that have fully ASCII names
+
+Returns a dynamic array of findfile_t that should be freed with VEC_FREE
+=================
+*/
+static findfile_t* COM_FindWildPacks (const char *dir)
+{
+	findfile_t *p, *pfiles = NULL;
+	for (p = Sys_FindFirst (dir, NULL); p; p = Sys_FindNext (p))
+	{
+		const char *ext = COM_FileGetExtension (p->name);
+		if ((p->attribs & FA_DIRECTORY) || !q_strascii (p->name) || q_strcasecmp (ext, "pk3") != 0)
+			continue;
+
+		if (strlen (p->name) >= 8 && q_strncasecmp (p->name, "pak", 3) == 0)
+		{
+			const char *paknum, *numend;
+			int ndigits = 0;
+			numend = ext - 1;
+
+			for (paknum = &p->name[3]; paknum < numend; ++paknum)
+				ndigits += q_isdigit (*paknum);
+			
+			if (ndigits >= (int)(numend - &p->name[3]))
+				continue;
+		}
+
+		VEC_PUSH (pfiles, *p);
+	}
+
+	if (pfiles)
+		qsort (pfiles, VEC_SIZE (pfiles), sizeof(findfile_t), &COM_PackNameCompare);
+
+	return pfiles;
+} 
 
 /*
 =================
@@ -2450,19 +2139,19 @@ static void COM_AddEnginePak (void)
 {
 	int			i;
 	char		pakfile[MAX_OSPATH];
-	pack_t		*pak = NULL;
+	int			pak = 0;
 	qboolean	modified = com_modified;
 
 	if (host_parms->exedir)
 	{
 		q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, host_parms->exedir);
-		pak = COM_LoadPackFile (pakfile);
+		pak = QFS_LoadPackFile (pakfile);
 	}
 
 	if (!pak)
 	{
 		q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, host_parms->basedir);
-		pak = COM_LoadPackFile (pakfile);
+		pak = QFS_LoadPackFile (pakfile);
 	}
 
 	if (!pak)
@@ -2470,7 +2159,7 @@ static void COM_AddEnginePak (void)
 		for (i = 0; i < com_numbasedirs; i++)
 		{
 			q_snprintf (pakfile, sizeof(pakfile), "%s/" ENGINE_PAK, com_basedirs[i]);
-			pak = COM_LoadPackFile (pakfile);
+			pak = QFS_LoadPackFile (pakfile);
 			if (pak)
 				break;
 		}
@@ -2496,11 +2185,13 @@ COM_AddGameDirectory -- johnfitz -- modified based on topaz's tutorial
 void COM_AddGameDirectory (const char *dir)
 {
 	const char *base;
-	int i, j;
+	int i, j, k;
 	unsigned int path_id;
 	searchpath_t *search;
-	pack_t *pak;
+	findfile_t* wildpacks;
+	int pak = 0;
 	char pakfile[MAX_OSPATH];
+	static const char* pkext[2] = { "pak", "pk3" };
 
 	if (*com_gamenames)
 		q_strlcat(com_gamenames, ";", sizeof(com_gamenames));
@@ -2541,11 +2232,18 @@ void COM_AddGameDirectory (const char *dir)
 		search->next = com_searchpaths;
 		com_searchpaths = search;
 
-		// add any pak files in the format pak0.pak pak1.pak, ...
+		// add any pak files (or pk3 files) in the format pak0.pak pak1.pak, ...
+		// pak files and pk3 files can not have the same number, if it exists
+		// with both extensions, the pak file will be used and the pk3 file ignored
 		for (i = 0; ; i++)
 		{
-			q_snprintf (pakfile, sizeof(pakfile), "%s/pak%i.pak", com_gamedir, i);
-			pak = COM_LoadPackFile (pakfile);
+			for (k = 0; k < countof(pkext); ++k)
+			{
+				q_snprintf (pakfile, sizeof(pakfile), "%s/pak%i.%s", com_gamedir, i, pkext[k]);
+				pak = QFS_LoadPackFile (pakfile);
+				if (pak)
+					break;
+			}
 			if (!pak)
 				break;
 
@@ -2559,6 +2257,26 @@ void COM_AddGameDirectory (const char *dir)
 			if (i == 0 && j == 0 && path_id == 1u)
 				COM_AddEnginePak ();
 		}
+
+		// Add any "wild" pk3 packs outside of the pakN scheme
+		wildpacks = COM_FindWildPacks (com_gamedir);
+		if (wildpacks)
+		{
+			for (i = 0; i < (int)VEC_SIZE (wildpacks); ++i)
+			{
+				q_snprintf (pakfile, sizeof(pakfile), "%s/%s", com_gamedir, wildpacks[i].name);
+				pak = QFS_LoadPackFile (pakfile);
+				if (pak)
+				{
+					search = (searchpath_t *) Z_Malloc (sizeof(searchpath_t));
+					search->path_id = path_id;
+					search->pack = pak;
+					search->next = com_searchpaths;
+					com_searchpaths = search;
+				}
+			}
+			VEC_FREE (wildpacks);
+		}
 	}
 }
 
@@ -2570,11 +2288,8 @@ void COM_ResetGameDirectories(const char *newgamedirs)
 	while (com_searchpaths != com_base_searchpaths)
 	{
 		if (com_searchpaths->pack)
-		{
-			Sys_FileClose (com_searchpaths->pack->handle);
-			Z_Free (com_searchpaths->pack->files);
-			Z_Free (com_searchpaths->pack);
-		}
+			QFS_FreePack(com_searchpaths->pack);
+
 		search = com_searchpaths->next;
 		Z_Free (com_searchpaths);
 		com_searchpaths = search;
@@ -3447,176 +3162,6 @@ void COM_InitFilesystem (void) //johnfitz -- modified based on topaz's tutorial
 	COM_CheckRegistered ();
 }
 
-
-/* The following FS_*() stdio replacements are necessary if one is
- * to perform non-sequential reads on files reopened on pak files
- * because we need the bookkeeping about file start/end positions.
- * Allocating and filling in the fshandle_t structure is the users'
- * responsibility when the file is initially opened. */
-
-size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh)
-{
-	long byte_size;
-	long bytes_read;
-	size_t nmemb_read;
-
-	if (!fh) {
-		errno = EBADF;
-		return 0;
-	}
-	if (!ptr) {
-		errno = EFAULT;
-		return 0;
-	}
-	if (!size || !nmemb) {	/* no error, just zero bytes wanted */
-		errno = 0;
-		return 0;
-	}
-
-	byte_size = nmemb * size;
-	if (byte_size > fh->length - fh->pos)	/* just read to end */
-		byte_size = fh->length - fh->pos;
-	bytes_read = fread(ptr, 1, byte_size, fh->file);
-	fh->pos += bytes_read;
-
-	/* fread() must return the number of elements read,
-	 * not the total number of bytes. */
-	nmemb_read = bytes_read / size;
-	/* even if the last member is only read partially
-	 * it is counted as a whole in the return value. */
-	if (bytes_read % size)
-		nmemb_read++;
-
-	return nmemb_read;
-}
-
-int FS_fseek(fshandle_t *fh, long offset, int whence)
-{
-/* I don't care about 64 bit off_t or fseeko() here.
- * the quake/hexen2 file system is 32 bits, anyway. */
-	int ret;
-
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-
-	/* the relative file position shouldn't be smaller
-	 * than zero or bigger than the filesize. */
-	switch (whence)
-	{
-	case SEEK_SET:
-		break;
-	case SEEK_CUR:
-		offset += fh->pos;
-		break;
-	case SEEK_END:
-		offset = fh->length + offset;
-		break;
-	default:
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (offset < 0) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	if (offset > fh->length)	/* just seek to end */
-		offset = fh->length;
-
-	ret = fseek(fh->file, fh->start + offset, SEEK_SET);
-	if (ret < 0)
-		return ret;
-
-	fh->pos = offset;
-	return 0;
-}
-
-int FS_fclose(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fclose(fh->file);
-}
-
-long FS_ftell(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fh->pos;
-}
-
-void FS_rewind(fshandle_t *fh)
-{
-	if (!fh) return;
-	clearerr(fh->file);
-	fseek(fh->file, fh->start, SEEK_SET);
-	fh->pos = 0;
-}
-
-int FS_feof(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	if (fh->pos >= fh->length)
-		return -1;
-	return 0;
-}
-
-int FS_ferror(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return ferror(fh->file);
-}
-
-int FS_fgetc(fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return EOF;
-	}
-	if (fh->pos >= fh->length)
-		return EOF;
-	fh->pos += 1;
-	return fgetc(fh->file);
-}
-
-char *FS_fgets(char *s, int size, fshandle_t *fh)
-{
-	char *ret;
-
-	if (FS_feof(fh))
-		return NULL;
-
-	if (size > (fh->length - fh->pos) + 1)
-		size = (fh->length - fh->pos) + 1;
-
-	ret = fgets(s, size, fh->file);
-	fh->pos = ftell(fh->file) - fh->start;
-
-	return ret;
-}
-
-long FS_filelength (fshandle_t *fh)
-{
-	if (!fh) {
-		errno = EBADF;
-		return -1;
-	}
-	return fh->length;
-}
-
 /*
 ============================================================================
 								LOCALIZATION
@@ -3712,7 +3257,7 @@ qboolean LOC_LoadFile (const char *file)
 
 	memset(&archive, 0, sizeof(archive));
 
-	localization.text = (char *) COM_LoadMallocFile (file, NULL);
+	localization.text = (char *) QFS_LoadMallocFile (file, NULL, NULL);
 
 	if (!localization.text)
 	{
@@ -4583,4 +4128,73 @@ size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src)
 	dst[i++] = '\0';
 
 	return i;
+}
+
+/*
+==================
+UTF8_FromIBM437
+
+Transliterates a string from IBM code page 437 to UTF-8 encoding.
+cp437 was often used in MSDOS and its ghost lives on in some file formats.
+
+Returns the number of written characters (including the NUL terminator)
+if a valid output buffer is provided (dst is non-NULL, maxbytes > 0),
+or the total amount of space necessary to encode the entire src string
+if dst is NULL and maxbytes is 0.
+
+==================
+*/
+size_t UTF8_FromIBM437 (char* dst, size_t maxbytes, const char* src)
+{
+	const char *p;
+	char *d;
+	static const uint16_t ibm437_high[0x80] =	/*Code points from 0x80-0xff, below it's just ASCII*/
+	{
+		0x00c7, 0x00fc, 0x00e9, 0x00e2, 0x00e4, 0x00e0, 0x00e5, 0x00e7, 0x00ea, 0x00eb, 0x00e8, 0x00ef, 0x00ee, 0x00ec, 0x00c4, 0x00c5,
+		0x00c9, 0x00e6, 0x00c6, 0x00f4, 0x00f6, 0x00f2, 0x00fb, 0x00f9, 0x00ff, 0x00d6, 0x00dc, 0x00a2, 0x00a3, 0x00a5, 0x20a7, 0x0192,
+		0x00e1, 0x00ed, 0x00f3, 0x00fa, 0x00f1, 0x00d1, 0x00aa, 0x00ba, 0x00bf, 0x2310, 0x00ac, 0x00bd, 0x00bc, 0x00a1, 0x00ab, 0x00bb,
+		0x2591, 0x2592, 0x2593, 0x2502, 0x2524, 0x2561, 0x2562, 0x2556, 0x2555, 0x2563, 0x2551, 0x2557, 0x255d, 0x255c, 0x255b, 0x2510,
+		0x2514, 0x2534, 0x252c, 0x251c, 0x2500, 0x253c, 0x255e, 0x255f, 0x255a, 0x2554, 0x2569, 0x2566, 0x2560, 0x2550, 0x256c, 0x2567,
+		0x2568, 0x2564, 0x2565, 0x2559, 0x2558, 0x2552, 0x2553, 0x256b, 0x256a, 0x2518, 0x250c, 0x2588, 0x2584, 0x258c, 0x2590, 0x2580,
+		0x03b1, 0x00df, 0x0393, 0x03c0, 0x03a3, 0x03c3, 0x00b5, 0x03c4, 0x03a6, 0x0398, 0x03a9, 0x03b4, 0x221e, 0x03c6, 0x03b5, 0x2229,
+		0x2261, 0x00b1, 0x2265, 0x2264, 0x2320, 0x2321, 0x00f7, 0x2248, 0x00b0, 0x2219, 0x00b7, 0x221a, 0x207f, 0x00b2, 0x25a0, 0x00a0
+	};
+
+	if (maxbytes == 0)
+	{
+		size_t cnt = 1;
+		if (dst != NULL)
+			return 0;
+
+		for (p = src; *p; ++p)
+		{
+			byte ch = (byte)*p;
+			if (ch & 0x80)
+				cnt += UTF8_CodePointLength (ibm437_high[ch & 0x7f]);
+			else
+				cnt += 1;
+		}
+		return cnt;
+	}
+
+	for (p = src, d = dst; *p && maxbytes > 1; ++p)
+	{
+		byte ch = (byte)*p;
+		if (ch & 0x80)
+		{
+			size_t n = UTF8_WriteCodePoint (d, maxbytes, ibm437_high[ch & 0x7f]);
+			if (n >= maxbytes)
+				break;
+			d += n;
+			maxbytes -= n;
+		}
+		else
+		{
+			*d++ = *p;
+			maxbytes -= 1;
+		}
+	}
+
+	*d++ = '\0';
+	return (size_t)(d - dst);
 }

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -117,8 +117,8 @@ typedef struct sizebuf_s
 	qboolean	allowoverflow;	// if false, do a Sys_Error
 	qboolean	overflowed;		// set to true if the buffer size failed
 	byte		*data;
-	int		maxsize;
-	int		cursize;
+	int32_t		maxsize;
+	int32_t		cursize;
 } sizebuf_t;
 
 void SZ_Alloc (sizebuf_t *buf, int startsize);
@@ -208,10 +208,10 @@ static inline void ToggleBit (uint32_t *arr, uint32_t i)
 #define host_bigendian 0
 #endif
 
-#define BigShort(s)    ((short)SDL_SwapBE16((s)))
-#define LittleShort(s) ((short)SDL_SwapLE16((s)))
-#define BigLong(l)     ((int)SDL_SwapBE32((l)))
-#define LittleLong(l)  ((int)SDL_SwapLE32((l)))
+#define BigShort(s)    ((int16_t)SDL_SwapBE16((s)))
+#define LittleShort(s) ((int16_t)SDL_SwapLE16((s)))
+#define BigLong(l)     ((int32_t)SDL_SwapBE32((l)))
+#define LittleLong(l)  ((int32_t)SDL_SwapLE32((l)))
 #define BigFloat(f)    SDL_SwapFloatBE((f))
 #define LittleFloat(f) SDL_SwapFloatLE((f))
 
@@ -277,6 +277,9 @@ extern char *q_strupr (char *str);
 /* snprintf, vsnprintf : always use our versions. */
 extern int q_snprintf (char *str, size_t size, const char *format, ...) FUNC_PRINTF(3,4);
 extern int q_vsnprintf(char *str, size_t size, const char *format, va_list args) FUNC_PRINTF(3,0);
+
+/* q_strascii : check if a string contains only ascii */
+extern qboolean q_strascii (const char* str);
 
 #define PLURAL(count)	((int)(count)), ((int)(count) == 1 ? "" : "s")
 
@@ -362,6 +365,8 @@ uint32_t UTF8_ReadCodePoint (const char **src);
 size_t UTF8_FromQuake (char *dst, size_t maxbytes, const char *src);
 size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src);
 
+size_t UTF8_FromIBM437 (char* dst, size_t maxbytes, const char* src);
+
 #define UNICODE_UNKNOWN		0xFFFD
 #define UNICODE_MAX			0x10FFFF
 
@@ -372,34 +377,19 @@ size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src);
 //============================================================================
 
 // QUAKEFS
-typedef struct
-{
-	char	name[MAX_QPATH];
-	int		filepos, filelen;
-} packfile_t;
-
-typedef struct pack_s
-{
-	char	filename[MAX_OSPATH];
-	int		handle;
-	int		numfiles;
-	packfile_t	*files;
-} pack_t;
-
 typedef struct searchpath_s
 {
 	unsigned int path_id;	// identifier assigned to the game directory
 					// Note that <install_dir>/game1 and
 					// <userdir>/game1 have the same id.
 	char	filename[MAX_OSPATH];
-	pack_t	*pack;			// only one of filename / pack will be used
+	int 	pack;			// only one of filename / pack will be used
 	struct searchpath_s	*next;
 } searchpath_t;
 
 extern searchpath_t *com_searchpaths;
 extern searchpath_t *com_base_searchpaths;
 
-extern THREAD_LOCAL qfileofs_t com_filesize;
 struct cache_user_s;
 
 #define MAX_BASEDIRS 64
@@ -408,22 +398,9 @@ extern	int		com_numbasedirs;
 extern	char	com_basedirs[MAX_BASEDIRS][MAX_OSPATH];
 extern	char	com_gamedir[MAX_OSPATH];
 extern	char	com_nightdivedir[MAX_OSPATH];
-extern	THREAD_LOCAL int	file_from_pak;	// global indicating that file came from a pak
 
 void COM_WriteFile (const char *filename, const void *data, int len);
 qboolean COM_WriteFile_OSPath (const char *filename, const void *data, size_t len);
-int COM_OpenFile (const char *filename, int *handle, unsigned int *path_id);
-int COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id);
-qboolean COM_FileExists (const char *filename, unsigned int *path_id);
-void COM_CloseFile (int h);
-
-// these procedures open a file using COM_FindFile and loads it into a proper
-// buffer. the buffer is allocated with a total size of com_filesize + 1. the
-// procedures differ by their buffer allocation method.
-byte *COM_LoadHunkFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the hunk.
-byte *COM_LoadMallocFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the system mem (malloc).
 
 // Opens the given path directly, ignoring search paths.
 // Returns NULL on failure, or else a '\0'-terminated malloc'ed buffer.
@@ -450,33 +427,6 @@ const char *COM_ParseStringNewline(const char *buffer);
 #define	FS_ENT_NONE		(0)
 #define	FS_ENT_FILE		(1 << 0)
 #define	FS_ENT_DIRECTORY	(1 << 1)
-
-/* The following FS_*() stdio replacements are necessary if one is
- * to perform non-sequential reads on files reopened on pak files
- * because we need the bookkeeping about file start/end positions.
- * Allocating and filling in the fshandle_t structure is the users'
- * responsibility when the file is initially opened. */
-
-typedef struct _fshandle_t
-{
-	FILE *file;
-	qboolean pak;	/* is the file read from a pak */
-	long start;	/* file or data start position */
-	long length;	/* file or data size */
-	long pos;	/* current position relative to start */
-} fshandle_t;
-
-size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh);
-int FS_fseek(fshandle_t *fh, long offset, int whence);
-long FS_ftell(fshandle_t *fh);
-void FS_rewind(fshandle_t *fh);
-int FS_feof(fshandle_t *fh);
-int FS_ferror(fshandle_t *fh);
-int FS_fclose(fshandle_t *fh);
-int FS_fgetc(fshandle_t *fh);
-char *FS_fgets(char *s, int size, fshandle_t *fh);
-long FS_filelength (fshandle_t *fh);
-
 
 extern struct cvar_s	registered;
 extern qboolean		standard_quake, rogue, hipnotic;

--- a/Quake/common.h
+++ b/Quake/common.h
@@ -117,8 +117,8 @@ typedef struct sizebuf_s
 	qboolean	allowoverflow;	// if false, do a Sys_Error
 	qboolean	overflowed;		// set to true if the buffer size failed
 	byte		*data;
-	int		maxsize;
-	int		cursize;
+	int32_t		maxsize;
+	int32_t		cursize;
 } sizebuf_t;
 
 void SZ_Alloc (sizebuf_t *buf, int startsize);
@@ -208,10 +208,10 @@ static inline void ToggleBit (uint32_t *arr, uint32_t i)
 #define host_bigendian 0
 #endif
 
-#define BigShort(s)    ((short)SDL_SwapBE16((s)))
-#define LittleShort(s) ((short)SDL_SwapLE16((s)))
-#define BigLong(l)     ((int)SDL_SwapBE32((l)))
-#define LittleLong(l)  ((int)SDL_SwapLE32((l)))
+#define BigShort(s)    ((int16_t)SDL_SwapBE16((s)))
+#define LittleShort(s) ((int16_t)SDL_SwapLE16((s)))
+#define BigLong(l)     ((int32_t)SDL_SwapBE32((l)))
+#define LittleLong(l)  ((int32_t)SDL_SwapLE32((l)))
 #define BigFloat(f)    SDL_SwapFloatBE((f))
 #define LittleFloat(f) SDL_SwapFloatLE((f))
 
@@ -277,6 +277,9 @@ extern char *q_strupr (char *str);
 /* snprintf, vsnprintf : always use our versions. */
 extern int q_snprintf (char *str, size_t size, const char *format, ...) FUNC_PRINTF(3,4);
 extern int q_vsnprintf(char *str, size_t size, const char *format, va_list args) FUNC_PRINTF(3,0);
+
+/* q_strascii : check if a string contains only ascii */
+extern qboolean q_strascii (const char* str);
 
 #define PLURAL(count)	((int)(count)), ((int)(count) == 1 ? "" : "s")
 
@@ -366,6 +369,8 @@ uint32_t UTF8_ReadCodePoint (const char **src);
 size_t UTF8_FromQuake (char *dst, size_t maxbytes, const char *src);
 size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src);
 
+size_t UTF8_FromIBM437 (char* dst, size_t maxbytes, const char* src);
+
 #define UNICODE_UNKNOWN		0xFFFD
 #define UNICODE_MAX			0x10FFFF
 
@@ -376,34 +381,19 @@ size_t UTF8_ToQuake (char *dst, size_t maxbytes, const char *src);
 //============================================================================
 
 // QUAKEFS
-typedef struct
-{
-	char	name[MAX_QPATH];
-	int		filepos, filelen;
-} packfile_t;
-
-typedef struct pack_s
-{
-	char	filename[MAX_OSPATH];
-	int		handle;
-	int		numfiles;
-	packfile_t	*files;
-} pack_t;
-
 typedef struct searchpath_s
 {
 	unsigned int path_id;	// identifier assigned to the game directory
 					// Note that <install_dir>/game1 and
 					// <userdir>/game1 have the same id.
 	char	filename[MAX_OSPATH];
-	pack_t	*pack;			// only one of filename / pack will be used
+	int 	pack;			// only one of filename / pack will be used
 	struct searchpath_s	*next;
 } searchpath_t;
 
 extern searchpath_t *com_searchpaths;
 extern searchpath_t *com_base_searchpaths;
 
-extern THREAD_LOCAL qfileofs_t com_filesize;
 struct cache_user_s;
 
 #define MAX_BASEDIRS 64
@@ -412,22 +402,9 @@ extern	int		com_numbasedirs;
 extern	char	com_basedirs[MAX_BASEDIRS][MAX_OSPATH];
 extern	char	com_gamedir[MAX_OSPATH];
 extern	char	com_nightdivedir[MAX_OSPATH];
-extern	THREAD_LOCAL int	file_from_pak;	// global indicating that file came from a pak
 
 void COM_WriteFile (const char *filename, const void *data, int len);
 qboolean COM_WriteFile_OSPath (const char *filename, const void *data, size_t len);
-int COM_OpenFile (const char *filename, int *handle, unsigned int *path_id);
-int COM_FOpenFile (const char *filename, FILE **file, unsigned int *path_id);
-qboolean COM_FileExists (const char *filename, unsigned int *path_id);
-void COM_CloseFile (int h);
-
-// these procedures open a file using COM_FindFile and loads it into a proper
-// buffer. the buffer is allocated with a total size of com_filesize + 1. the
-// procedures differ by their buffer allocation method.
-byte *COM_LoadHunkFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the hunk.
-byte *COM_LoadMallocFile (const char *path, unsigned int *path_id);
-	// allocates the buffer on the system mem (malloc).
 
 // Opens the given path directly, ignoring search paths.
 // Returns NULL on failure, or else a '\0'-terminated malloc'ed buffer.
@@ -454,33 +431,6 @@ const char *COM_ParseStringNewline(const char *buffer);
 #define	FS_ENT_NONE		(0)
 #define	FS_ENT_FILE		(1 << 0)
 #define	FS_ENT_DIRECTORY	(1 << 1)
-
-/* The following FS_*() stdio replacements are necessary if one is
- * to perform non-sequential reads on files reopened on pak files
- * because we need the bookkeeping about file start/end positions.
- * Allocating and filling in the fshandle_t structure is the users'
- * responsibility when the file is initially opened. */
-
-typedef struct _fshandle_t
-{
-	FILE *file;
-	qboolean pak;	/* is the file read from a pak */
-	long start;	/* file or data start position */
-	long length;	/* file or data size */
-	long pos;	/* current position relative to start */
-} fshandle_t;
-
-size_t FS_fread(void *ptr, size_t size, size_t nmemb, fshandle_t *fh);
-int FS_fseek(fshandle_t *fh, long offset, int whence);
-long FS_ftell(fshandle_t *fh);
-void FS_rewind(fshandle_t *fh);
-int FS_feof(fshandle_t *fh);
-int FS_ferror(fshandle_t *fh);
-int FS_fclose(fshandle_t *fh);
-int FS_fgetc(fshandle_t *fh);
-char *FS_fgets(char *s, int size, fshandle_t *fh);
-long FS_filelength (fshandle_t *fh);
-
 
 extern struct cvar_s	registered;
 extern qboolean		standard_quake, rogue, hipnotic, mg3;

--- a/Quake/filesys.c
+++ b/Quake/filesys.c
@@ -1,0 +1,1070 @@
+/*
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2002-2009 John Fitzgibbons and others
+Copyright (C) 2010-2014 QuakeSpasm developers
+Copyright (C) 2024-2024 ironwail developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+/*
+Implementation of the Quake File System, a virtual file system that can read
+contents from pack files or file system files in the search directories.
+
+Supported pack files are:
+
+	*Regular Quake .pak files that the original Quake supports
+
+	*Quake 3 .pk3 files (zip files with a different extension).
+
+		This support is limited to either zip entries compressed with
+		the regular DEFLATE method of zip files, or uncompressed entries.
+*/
+#include "quakedef.h"
+#include "filesys.h"
+#include "miniz.h"
+
+typedef struct
+{
+	char	name[MAX_QPATH];
+	int		filepos, filelen;
+} packfile_t;
+
+typedef struct file_handle_s
+{
+	void *data;
+	void *impl_data;
+	int fileno;
+	qboolean owns_data;
+	qboolean from_pak;
+	qfileofs_t offs;
+	qfileofs_t pak_offset;
+	qfileofs_t start, endtrim;
+	qfileofs_t (*filesize)(struct file_handle_s *handle);
+	size_t (*read)(struct file_handle_s *handle, void* buf, size_t sz);
+	void (*close)(struct file_handle_s *handle);
+	int (*seek)(struct file_handle_s *handle, qfileofs_t pos);
+} qfshandle_t;
+
+typedef struct pack_s
+{
+	FILE* 	handle;
+	char	filename[MAX_OSPATH];
+	int		numfiles;
+	packfile_t	*files;
+	void* impl_data;
+	int pakver;
+	qfshandle_t* (*open_file)(struct pack_s* pack, int idx, qboolean reopen_pack);
+} pack_t;
+// on-disk pakfile
+//
+typedef struct
+{
+	char	name[56];
+	int		filepos, filelen;
+} dpackfile_t;
+
+typedef struct
+{
+	char	id[4];
+	int		dirofs;
+	int		dirlen;
+} dpackheader_t;
+
+#define MAX_FILES_IN_PACK	2048
+#define MAX_PACK_FILES 32
+
+//Loaded pack files (.pak or .pk3)
+//Index 0 is just a placeholder so 0 can be used to indicate error. First pack is loaded at index 1.
+static pack_t* packs[1 + MAX_PACK_FILES] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+	NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+
+/*
+=================
+QFS_FreePackHandle
+
+Close a pack file and free the data.
+=================
+*/
+static void QFS_FreePackHandle (pack_t *pack)
+{
+	if (pack != NULL)
+	{
+		fclose (pack->handle);
+		if (pack->impl_data)
+		{
+			if (pack->pakver == 3)
+				mz_zip_reader_end ((mz_zip_archive*)pack->impl_data);
+			free (pack->impl_data);
+		}
+		if (pack->files)
+			free (pack->files);
+		free (pack);
+	}
+}
+
+/*
+=================
+QFS_RegisterPack
+
+Add a pack to the program-wide array of packs.
+Will return 0 if the array is already full and the pack
+is closed and freed.
+=================
+*/
+static int QFS_RegisterPack (pack_t *pack)
+{
+	for (size_t i = 1; i < countof(packs); ++i)
+	{
+		if (packs[i] == NULL)
+		{
+			packs[i] = pack;
+			return (int)i;
+		}
+	}
+	QFS_FreePackHandle (pack);
+
+	Sys_Printf ("WARNING: Too many pack files loaded.");
+	return 0;
+}
+
+
+static void QFS_CheckHandle (qfshandle_t* handle)
+{
+	if (handle == NULL || handle->data == NULL)
+		Sys_Error ("Attempting to read from invalid file handle");
+}
+
+static void* QFS_Alloc (size_t sz)
+{
+	void *palloc = calloc (1, sz);
+	if (palloc == NULL)
+		Sys_Error ("QFS_Alloc of size %" SDL_PRIu64 " failed.", (uint64_t)sz);
+	
+	return palloc;
+}
+
+static qfshandle_t* QFS_AllocHandle (void)
+{
+	return (qfshandle_t *)QFS_Alloc (sizeof(qfshandle_t));
+}
+
+/*============
+FS_*
+file_handle_t implementation functions for regular disk files
+============
+*/
+static void FS_Close (qfshandle_t* handle)
+{
+	if (handle)
+	{
+		if (handle->owns_data)
+			fclose ((FILE*)handle->data);
+		free (handle);
+	}
+}
+
+static size_t FS_Read(qfshandle_t* handle, void* buf, size_t sz)
+{
+	QFS_CheckHandle (handle);
+	
+	sz = fread (buf, 1, sz, (FILE*)handle->data);
+	handle->offs += sz;
+	return sz;
+}
+
+static qfileofs_t FS_FileSize (qfshandle_t* handle)
+{
+	return Sys_filelength ((FILE*)handle->data);
+}
+
+int FS_Seek(qfshandle_t* handle, qfileofs_t pos)
+{
+	return Sys_fseek ((FILE*)handle->data, pos, SEEK_SET);
+}
+
+static qfshandle_t* FS_Open (const char* filename)
+{
+	FILE *stdio_handle = fopen (filename, "rb");
+	if (stdio_handle == NULL)
+		return NULL;
+
+	qfshandle_t* handle = QFS_AllocHandle ();
+	if (handle)
+	{
+		handle->data = stdio_handle;
+		handle->close = &FS_Close;
+		handle->read = &FS_Read;
+		handle->filesize = &FS_FileSize;
+		handle->seek = &FS_Seek;
+		handle->owns_data = true;
+	}
+	return handle;
+}
+
+/*
+============
+PAK_*
+qfshandle_t implementation functions for PAK file content files
+============
+*/
+static void PAK_Close (qfshandle_t* handle)
+{
+	if (handle)
+	{
+		if (handle->owns_data)
+		{
+			pack_t* pack = (pack_t*)handle->data;
+			pack->files = NULL;
+			QFS_FreePackHandle (pack);
+		}
+		if (handle->impl_data)
+			free (handle->impl_data);
+		free (handle);
+	}
+}
+
+static size_t PAK_Read (qfshandle_t* handle, void* buf, size_t sz)
+{
+	pack_t* pack;
+	qfileofs_t actualofs;
+	size_t filesize;
+
+	QFS_CheckHandle (handle);
+	pack = (pack_t*)handle->data;
+	actualofs = handle->offs + handle->start;
+	
+	filesize = (size_t)handle->filesize(handle);
+	if (actualofs + sz > filesize)
+		sz = filesize - (size_t)actualofs;
+	
+	if (sz > 0 && Sys_fseek (pack->handle, handle->pak_offset + handle->offs + handle->start, SEEK_SET) == 0)
+	{
+		sz = fread (buf, 1, sz, pack->handle);
+		handle->offs += sz;
+	}
+	
+	return sz;
+}
+
+static qfileofs_t PAK_FileSize (qfshandle_t* handle)
+{
+	pack_t* pack = (pack_t*)handle->data;
+	return pack->files[handle->fileno].filelen;
+}
+
+int PAK_Seek(qfshandle_t* handle, qfileofs_t pos)
+{
+	handle->offs = pos;
+	return 0;
+}
+
+static qfshandle_t* PAK_Open(pack_t* pack, int idx, qboolean reopen_pack)
+{
+	pack_t* refpack;
+	qfshandle_t *handle = QFS_AllocHandle ();
+	handle->fileno = idx;
+	handle->close = &PAK_Close;
+	handle->read = &PAK_Read;
+	handle->filesize = &PAK_FileSize;
+	handle->seek = &PAK_Seek;
+
+	if (reopen_pack)
+	{
+		//This will create a shallow copy that doesn't copy all the file
+		//entries, but references the original. This should be fine
+		handle->owns_data = true;
+		pack_t* newpack = (pack_t*)QFS_Alloc (sizeof(pack_t));
+		*newpack = *pack;
+		newpack->handle = fopen (pack->filename, "rb");
+		if (newpack->handle == NULL)
+			Sys_Error ("%s failed to reopen.", pack->filename);
+		handle->data = newpack;
+	}
+	else
+	{
+		handle->data = (void*)pack;
+	}
+
+	//Position PAK at the selected file
+	refpack = (pack_t*)handle->data;
+	handle->pak_offset = refpack->files[idx].filepos;
+	return handle;
+}
+
+/*
+============
+ZIP_*
+qfshandle_t implementation functions for pk3 (zip) file content files
+============
+*/
+
+typedef struct
+{
+	byte* inbuf;
+	byte* outbuf;
+	qfileofs_t foffs_in, foffs_out;
+	size_t bsz_in, bsz_out;	//Max buffer sizes
+	size_t readsz_in;	//Valid data in input buffer
+	size_t p_out;	//Bytes already read from the out buffer
+	size_t p_in;	//Bytes already consumed from input buffer
+	size_t out_read_ptr;	//indicates how much of the out buffer has been read by user
+	qboolean eof_flag;	//End reached on deflate stream
+	mz_zip_archive_file_stat stat;
+	tinfl_decompressor infl;
+}
+inflbuffers_t;
+
+static size_t ZIP_LowLevelRead (void *opaque, mz_uint64 ofs, void *buf, size_t n)
+{
+	FILE *handle = (FILE*)opaque;
+
+	if (ofs > LONG_MAX || Sys_fseek (handle, ofs, SEEK_SET) != 0)
+		Sys_Error ("Invalid read of at offset %" SDL_PRIu64, (uint64_t)n);
+
+	return fread (buf, 1, n, handle);
+}
+
+static void ZIP_Close (qfshandle_t* handle)
+{
+	inflbuffers_t* zip = (inflbuffers_t*)handle->impl_data;
+	handle->impl_data = NULL;
+	if (zip)
+	{
+		if (zip->inbuf)
+			free (zip->inbuf);
+		if (zip->outbuf)
+			free (zip->outbuf);
+		free (zip);
+	}
+	
+	PAK_Close (handle);
+}
+
+static size_t ZIP_Read (qfshandle_t* handle, void* buf, size_t sz)
+{
+	inflbuffers_t *p = (inflbuffers_t*)handle->impl_data;
+	pack_t *pack = (pack_t*)handle->data;
+	mz_zip_archive *z = (mz_zip_archive*)pack->impl_data;
+	
+	if (p->stat.m_is_directory || p->stat.m_uncomp_size == 0 || sz == 0 )
+	{
+		return 0;
+	}
+
+	byte* outbuf = (byte*)buf;
+	size_t rd = 0;
+
+	tinfl_status status = TINFL_STATUS_DONE;
+	for (;;)
+	{
+		if (p->p_out >= p->bsz_out || p->eof_flag)
+		{
+			size_t ncpy = q_min (p->p_out - p->out_read_ptr, sz - rd);
+			if (outbuf != NULL)
+			{
+				memcpy (outbuf, p->outbuf + p->out_read_ptr, ncpy);
+				outbuf += ncpy;
+			}
+			rd += ncpy;
+			p->out_read_ptr += ncpy;
+
+			handle->offs += ncpy;
+			
+			if (p->out_read_ptr >= p->p_out)
+				p->out_read_ptr = p->p_out = 0;
+			
+			if (rd >= sz || (p->p_out == 0 && p->eof_flag))
+				return rd;
+		}
+
+		if (p->p_in >= p->readsz_in)
+		{
+			size_t sz = (size_t)q_min ((qfileofs_t)p->bsz_in, (qfileofs_t)p->stat.m_comp_size - p->foffs_in);
+			p->readsz_in = z->m_pRead (z->m_pIO_opaque,
+				(mz_uint64)(handle->pak_offset + p->foffs_in),
+				p->inbuf, sz);
+			
+			if (p->readsz_in != sz)
+				Sys_Error ("File I/O error on %s", pack->filename);
+			
+			p->p_in = 0;
+			p->foffs_in += p->readsz_in;
+		}
+
+		size_t szin = p->readsz_in - p->p_in, szout = p->bsz_out - p->p_out;
+
+		status = tinfl_decompress (&p->infl,
+				(mz_uint8*)p->inbuf + p->p_in, &szin,
+				(mz_uint8*)p->outbuf,
+				(mz_uint8*)p->outbuf + p->p_out, &szout,
+				(qfileofs_t)p->stat.m_comp_size >= p->foffs_in ? TINFL_FLAG_HAS_MORE_INPUT : 0 | TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
+		
+		p->p_in += szin;
+		p->p_out += szout;
+		p->foffs_out += szout;
+		p->eof_flag = status == TINFL_STATUS_DONE;
+
+		if (status < TINFL_STATUS_DONE)
+			Sys_Error ("Failed to inflate %s in %s", p->stat.m_filename, pack->filename);
+	}
+}
+
+int ZIP_Seek(qfshandle_t* handle, qfileofs_t pos)
+{
+	inflbuffers_t *p = (inflbuffers_t*)handle->impl_data;
+	qfileofs_t buf_start = handle->offs - (qfileofs_t)p->out_read_ptr;
+
+	if (pos >= buf_start && pos - buf_start <= (qfileofs_t)p->p_out)
+	{
+		//good, we're still inside our output buffer
+		p->out_read_ptr = (size_t)(pos - buf_start);
+		return 0;
+	}
+	else if (pos > buf_start + (qfileofs_t)p->p_out)
+	{
+		//We need to skip forward
+		size_t skipcnt = (size_t)(pos - handle->offs);
+		return ZIP_Read (handle, NULL, skipcnt) == skipcnt ? 0 : -1;
+	}
+	else
+	{
+		//Start from the beginning
+		p->out_read_ptr = p->p_out = p->readsz_in = 0;
+		p->foffs_out = p->foffs_in = handle->offs = 0;
+		p->eof_flag = false;
+		tinfl_init (&p->infl);
+		return ZIP_Read (handle, NULL, (size_t)pos) == (size_t)pos ? 0 : -1;
+	}
+}
+
+static qfshandle_t* ZIP_Open (pack_t* pack, int idx, qboolean reopen_pack)
+{
+	mz_zip_archive* za;
+	pack_t* refpack = pack;
+	uint32_t local_header1 = 0;
+	uint16_t local_header2[2];
+	qfshandle_t *handle = PAK_Open (pack, idx, reopen_pack);
+	
+	handle->close = &ZIP_Close;
+
+	inflbuffers_t *zip = (inflbuffers_t*)QFS_Alloc (sizeof(inflbuffers_t));
+
+	if (reopen_pack)
+	{
+		pack_t* newpack = (pack_t*)handle->data;	//PAK_Open created a clone for us
+		za = (mz_zip_archive*)QFS_Alloc (sizeof (mz_zip_archive));
+		za->m_pRead = &ZIP_LowLevelRead;
+		za->m_pIO_opaque = newpack->handle;
+
+		if (!mz_zip_reader_init (za, Sys_filelength (refpack->handle), 0))
+			Sys_Error ("%s failed to reopen.", refpack->filename);
+		newpack->impl_data = za;
+		refpack = newpack;
+	}
+
+	za = (mz_zip_archive*)refpack->impl_data;
+	
+	mz_zip_reader_file_stat (za, refpack->files[idx].filepos, &zip->stat);
+	if (!zip->stat.m_is_supported)
+		Sys_Error("Unsupported zip file entry %s", refpack->files[idx].name);
+	
+	if (za->m_pRead(za->m_pIO_opaque, zip->stat.m_local_header_ofs, &local_header1, sizeof(local_header1)) != sizeof(local_header1)
+		|| SDL_SwapLE32(local_header1) != 0x04034b50
+		|| za->m_pRead(za->m_pIO_opaque, zip->stat.m_local_header_ofs + 26, &local_header2, sizeof(local_header2)) != sizeof(local_header2))
+	{
+		Sys_Error ("Truncated or corrupt directory entry in %s", refpack->filename);
+	}
+	
+	handle->pak_offset = zip->stat.m_local_header_ofs + 30
+		+ SDL_SwapLE16 (local_header2[0])
+		+ SDL_SwapLE16 (local_header2[1]);
+	
+	if (handle->pak_offset + zip->stat.m_comp_size > za->m_archive_size)
+		Sys_Error ("Truncated zip file %s", refpack->filename);
+
+	if (zip->stat.m_method)
+	{
+		handle->impl_data = zip;
+
+		zip->bsz_in = q_min ((size_t)zip->stat.m_comp_size, MZ_ZIP_MAX_IO_BUF_SIZE / 2);
+		zip->inbuf = (byte*)malloc(zip->bsz_in);
+
+		zip->bsz_out = MZ_ZIP_MAX_IO_BUF_SIZE;
+		zip->outbuf = (byte*)malloc (zip->bsz_out);
+
+		tinfl_init (&zip->infl);
+		handle->read = &ZIP_Read;
+		handle->seek = &ZIP_Seek;
+	}
+	else
+	{
+		//An uncompressed zip entry - we can just read with the
+		//regular PAK read functions
+		handle->read = &PAK_Read;
+		handle->seek = &PAK_Seek;
+		free (zip);
+	}
+
+	return handle;
+}
+
+/*
+=================
+QFS_GetPack
+
+Get the pack with the specified number, or NULL of there is none.
+If parameter unregister is set, it will be removed from the
+program wide list and the caller becomes the new owner.
+=================
+*/
+static pack_t* QFS_GetPack (int num, qboolean unregister)
+{
+	if (num > 0 && num < MAX_PACK_FILES)
+	{
+		pack_t* pack = packs[num];
+		if (unregister)
+			packs[num] = NULL;
+		return pack;
+	}
+	return NULL;
+}
+
+const char* QFS_PackInfoName (int packid)
+{
+	pack_t* pack = QFS_GetPack (packid, false);
+	return pack ? pack->filename : NULL;
+}
+
+int QFS_PackInfoNumFiles (int packid)
+{
+	pack_t* pack = QFS_GetPack (packid, false);
+	return pack ? pack->numfiles : 0;
+}
+
+void QFS_FreePack (int packid)
+{
+	pack_t* pack = QFS_GetPack (packid, true);
+	QFS_FreePackHandle (pack);
+}
+
+void QFS_Shutdown (void)
+{
+	for (size_t i = 1; i < countof(packs); ++i)
+	{
+		if (packs[i] != NULL)
+		{
+			QFS_FreePackHandle(packs[i]);
+			packs[i] = NULL;
+		}
+	}
+}
+
+qfileofs_t QFS_PackInfoEntrySize (int packid, int idx)
+{
+	pack_t* pack = QFS_GetPack (packid, false);
+	if (pack && idx >= 0 && idx < pack->numfiles)
+		return pack->files[idx].filelen;
+
+	return 0; 
+}
+
+const char* QFS_PackInfoEntryName (int packid, int idx)
+{
+	pack_t* pack = QFS_GetPack (packid, false);
+	if (pack && idx >= 0 && idx < pack->numfiles)
+		return pack->files[idx].name;
+	
+	return NULL;
+}
+/*
+=================
+QFS_LoadPAKFile -- johnfitz -- modified based on topaz's tutorial
+
+Takes an explicit (not game tree related) path to a pak file.
+
+Loads the header and directory, adding the files at the beginning
+of the list so they override previous pack files.
+=================
+*/
+static int QFS_LoadPAKFile (const char *packfile)
+{
+	dpackheader_t	header;
+	int		i;
+	packfile_t	*newfiles;
+	int		numpackfiles;
+	pack_t		*pack;
+	FILE		*packhandle;
+	dpackfile_t	info[MAX_FILES_IN_PACK];
+
+	packhandle = fopen(packfile, "rb");
+	if (packhandle == NULL)
+		return 0;
+
+	if (fread(&header, 1, sizeof(header), packhandle) != sizeof(header) ||
+	    header.id[0] != 'P' || header.id[1] != 'A' || header.id[2] != 'C' || header.id[3] != 'K')
+		Sys_Error ("%s is not a packfile", packfile);
+
+	header.dirofs = (header.dirofs);
+	header.dirlen = (header.dirlen);
+
+	numpackfiles = header.dirlen / sizeof(dpackfile_t);
+
+	if (header.dirlen < 0 || header.dirofs < 0)
+	{
+		Sys_Error ("Invalid packfile %s (dirlen: %i, dirofs: %i)",
+					packfile, header.dirlen, header.dirofs);
+	}
+	if (!numpackfiles)
+	{
+		printf ("WARNING: %s has no files, ignored\n", packfile);
+		fclose (packhandle);
+		return 0;
+	}
+	if (numpackfiles > MAX_FILES_IN_PACK)
+		Sys_Error ("%s has %i files", packfile, numpackfiles);
+
+	newfiles = (packfile_t *) QFS_Alloc(numpackfiles * sizeof(packfile_t));
+
+	fseek (packhandle, header.dirofs, SEEK_SET);
+	if ((int)fread(info, 1, header.dirlen, packhandle) != header.dirlen)
+		Sys_Error ("Error reading %s", packfile);
+
+	// parse the directory
+	for (i = 0; i < numpackfiles; i++)
+	{
+		q_strlcpy (newfiles[i].name, info[i].name, sizeof(newfiles[i].name));
+		newfiles[i].filepos = (info[i].filepos);
+		newfiles[i].filelen = (info[i].filelen);
+	}
+
+	pack = (pack_t *) QFS_Alloc(sizeof (pack_t));
+	q_strlcpy (pack->filename, packfile, sizeof(pack->filename));
+	pack->handle = packhandle;
+	pack->numfiles = numpackfiles;
+	pack->files = newfiles;
+	pack->open_file = &PAK_Open;
+	pack->pakver = 1;
+
+	return QFS_RegisterPack (pack);
+}
+
+static int QFS_LoadPK3File(const char *packfile)
+{
+	mz_zip_archive *pk3;
+	FILE *pk3handle;
+	mz_uint i, numpackfiles;
+	packfile_t	*newfiles;
+	
+	pk3handle = fopen (packfile, "rb");
+	if (!pk3handle)
+		return 0;
+
+	pk3 = (mz_zip_archive*)QFS_Alloc (sizeof(mz_zip_archive));
+	pk3->m_pRead = ZIP_LowLevelRead;
+	pk3->m_pIO_opaque = pk3handle;
+	char buf[MZ_ZIP_MAX_ARCHIVE_FILENAME_SIZE];
+
+	if (!mz_zip_reader_init (pk3, (mz_uint64)Sys_filelength (pk3handle), 0))
+		Sys_Error("%s can not be opened as a .pk3 file.", packfile);
+	
+	mz_uint entrycount = pk3->m_total_files;
+	if (!entrycount)
+	{
+		printf("WARNING: %s has no files, ignored\n", packfile);
+		fclose(pk3handle);
+		free(pk3);
+		return 0;
+	}
+	
+	newfiles = (packfile_t *)QFS_Alloc(entrycount * sizeof(packfile_t));
+
+	for (i = 0, numpackfiles = 0; i < entrycount; ++i)
+	{
+		size_t len;
+		mz_zip_archive_file_stat st;
+		if (!mz_zip_reader_file_stat(pk3, i, &st))
+			Sys_Error ("Failed to get status of %s in %s.", buf, packfile);
+
+		if (!st.m_is_directory)
+		{
+			if (st.m_uncomp_size > INT_MAX)
+				Sys_Error("File %s in %s is too large.", buf, packfile);
+			
+			len = (size_t)mz_zip_reader_get_filename (pk3, i, buf, countof(buf));
+			if ((st.m_bit_flag & (1 << 11)) == 0 && !q_strascii (buf))
+			{
+				//A legacy encoding is used for the filename, by popular convention this is assumed to be IBM437 nowadays
+				char convbuf[sizeof(buf) * 3];
+				len = UTF8_FromIBM437 (convbuf, sizeof(convbuf), buf);
+				if (len <= sizeof(buf))
+					memcpy (buf, convbuf, len);
+				
+			}
+			if (len >= sizeof(newfiles[numpackfiles].name))
+				Sys_Error ("File name %s in %s exceeds maximum allowed length.", buf, packfile);
+
+			newfiles[numpackfiles].filelen = (int)st.m_uncomp_size;
+			newfiles[numpackfiles].filepos = (int)st.m_file_index;
+
+			q_strlcpy (newfiles[numpackfiles].name, buf, sizeof(newfiles[numpackfiles].name));
+			++numpackfiles;
+		}
+	}
+
+	pack_t* pack = (pack_t*) QFS_Alloc(sizeof(pack_t));
+	q_strlcpy(pack->filename, packfile, sizeof(pack->filename));
+	pack->handle = pk3handle;
+	pack->numfiles = numpackfiles;
+	pack->files = newfiles;
+	pack->open_file = &ZIP_Open;
+	pack->impl_data = pk3;
+	pack->pakver = 3;
+
+	return QFS_RegisterPack (pack);
+}
+
+int QFS_LoadPackFile(const char *packfile)
+{
+	if (q_strcasecmp (COM_FileGetExtension (packfile), "pk3") == 0)
+		return QFS_LoadPK3File (packfile);
+	else
+		return QFS_LoadPAKFile (packfile);		
+}
+
+/*
+===========
+QFS_FindFile
+
+Finds the file in the search path.
+Sets file to a new file handle, if reopen is true and file is in a pak,
+a new handle to the pak will be opened.
+If file is not set, it can be used for detecting a file's presence.
+===========
+*/
+static qfileofs_t QFS_FindFile (const char *filename, qfshandle_t** file, qboolean reopen, unsigned int *path_id)
+{
+	searchpath_t	*search;
+	char		netpath[MAX_OSPATH];
+	pack_t		*pak;
+	int			i;
+
+	if (file)
+		*file = NULL;
+//
+// search through the path, one element at a time
+//
+	for (search = com_searchpaths; search; search = search->next)
+	{
+		if (search->pack)	/* look through all the pak file elements */
+		{
+			pak = QFS_GetPack (search->pack, false);
+			if (!pak)
+				Sys_Error ("QFS_FindFile: invalid pack id.");
+
+			for (i = 0; i < pak->numfiles; i++)
+			{
+				if (strcmp(pak->files[i].name, filename) != 0)
+					continue;
+				// found it!
+				if (path_id)
+					*path_id = search->path_id;
+
+				if (file)
+					*file = pak->open_file(pak, i, reopen);
+				
+				return pak->files[i].filelen;
+			}
+		}
+		else	/* check a file in the directory tree */
+		{
+			if (!registered.value)
+			{ /* if not a registered version, don't ever go beyond base */
+				if ( strchr (filename, '/') || strchr (filename,'\\'))
+					continue;
+			}
+
+			q_snprintf (netpath, sizeof(netpath), "%s/%s",search->filename, filename);
+			if (! (Sys_FileType(netpath) & FS_ENT_FILE))
+				continue;
+
+			if (path_id)
+				*path_id = search->path_id;
+			
+			if (file)
+			{
+				*file = FS_Open (netpath);
+				if (*file == NULL)
+					return -1;
+				return Sys_filelength ((FILE*)(*file)->data);
+			}
+			else
+			{
+				return 0; /* dummy valid value for QFS_FileExists() */
+			}
+		}
+	}
+
+	if (developer.value)
+	{
+		const char *ext = COM_FileGetExtension (filename);
+
+		if (strcmp(ext, "pcx") != 0 &&
+			strcmp(ext, "tga") != 0 &&
+			strcmp(ext, "lit") != 0 &&
+			strcmp(ext, "png") != 0 &&
+			strcmp(ext, "jpg") != 0 &&
+			strcmp(ext, "lmp") != 0 &&
+			// music formats
+			strcmp (ext, "ogg") != 0 &&
+			strcmp (ext, "opus") != 0 &&
+			strcmp (ext, "flac") != 0 &&
+			strcmp (ext, "wav") != 0 &&
+			strcmp (ext, "it") != 0 &&
+			strcmp (ext, "s3m") != 0 &&
+			strcmp (ext, "xm") != 0 &&
+			strcmp (ext, "mod") != 0 &&
+			strcmp (ext, "umx") != 0 &&
+			// alternate model formats
+			strcmp(ext, "md5mesh") != 0 &&
+			strcmp (ext, "md3") != 0 &&
+			strcmp (ext, "skin") != 0 &&
+			// optional map files
+			strcmp(ext, "lit") != 0 &&
+			strcmp(ext, "vis") != 0 &&
+			strcmp(ext, "ent") != 0)
+			
+			Con_DPrintf ("FindFile: can't find %s\n", filename);
+		else
+			Con_DPrintf2 ("FindFile: can't find %s\n", filename);
+	}
+
+	if (file)
+		*file = NULL;
+		
+	return -1;
+}
+
+typedef enum
+{
+	LOADFILE_HUNK,
+	LOADFILE_MALLOC
+} loadfile_alloc_t;
+
+byte *QFS_LoadFile (const char *path, loadfile_alloc_t method, unsigned int *path_id, size_t* ldsize)
+{
+	byte	*buf;
+	char	base[32];
+	size_t	len, nread;
+
+	buf = NULL;	// quiet compiler warning
+
+// look for it in the filesystem or pack files
+	qfshandle_t *h = QFS_OpenFile (path, path_id);
+	if (h == NULL)
+		return NULL;
+	
+	len = (size_t)QFS_FileSize (h);
+	if (ldsize)
+		*ldsize = len;
+
+// extract the filename base name for hunk tag
+	COM_FileBase (path, base, sizeof(base));
+
+	switch (method)
+	{
+	case LOADFILE_HUNK:
+		buf = (byte *) Hunk_AllocNameNoFill (len+1, base);
+		break;
+	case LOADFILE_MALLOC:
+		buf = (byte *) malloc (len+1);
+		break;
+	default:
+		Sys_Error ("QFS_LoadFile: bad usehunk");
+	}
+
+	if (!buf)
+		Sys_Error ("QFS_LoadFile: not enough space for %s", path);
+
+	((byte *)buf)[len] = 0;
+
+	nread = QFS_ReadFile (h, buf, len);
+	QFS_CloseFile (h);
+	if (nread != len)
+		Sys_Error ("QFS_LoadFile: Error reading %s", path);
+
+	return buf;
+}
+
+byte *QFS_LoadHunkFile (const char *path, unsigned int *path_id, size_t* ldsize)
+{
+	return QFS_LoadFile (path, LOADFILE_HUNK, path_id, ldsize);
+}
+
+// returns malloc'd memory
+byte *QFS_LoadMallocFile (const char *path, unsigned int *path_id, size_t* ldsize)
+{
+	return QFS_LoadFile (path, LOADFILE_MALLOC, path_id, ldsize);
+}
+
+qboolean QFS_FileExists (const char *filename, unsigned int *path_id)
+{
+	qfileofs_t ret = QFS_FindFile (filename, NULL, false, path_id);
+	return (ret == -1) ? false : true;
+}
+
+qfshandle_t* QFS_OpenFile (const char *filename, unsigned int *path_id)
+{
+	qfshandle_t* handle;
+	if (QFS_FindFile (filename, &handle, false, path_id) >= 0)
+		return handle;
+	return NULL;
+}
+
+qfshandle_t* QFS_FOpenFile (const char *filename, unsigned int *path_id)
+{
+	qfshandle_t* handle;
+	if (QFS_FindFile (filename, &handle, true, path_id) >= 0)
+		return handle;
+	return NULL;
+}
+
+qboolean QFS_Eof (qfshandle_t* handle)
+{
+	if (!handle || handle->offs - handle->endtrim >= handle->filesize(handle) - handle->start)
+		return true;
+	return false;
+}
+
+size_t QFS_ReadFile(qfshandle_t* handle, void* buf, size_t size)
+{
+	if (handle)
+	{
+		qfileofs_t filesize = handle->filesize(handle);
+		if (handle->offs + (qfileofs_t)size > filesize - handle->endtrim)
+			size = (size_t)(filesize - handle->endtrim);
+
+		return handle->read(handle, buf, size);
+	}
+	return 0;
+}
+
+qfileofs_t QFS_FileSize (qfshandle_t* handle)
+{
+	return handle ? handle->filesize(handle) - handle->start - handle->endtrim : 0;
+}
+
+void QFS_CloseFile (qfshandle_t *handle)
+{
+	if (handle)
+		handle->close (handle);
+}
+
+qfileofs_t QFS_Seek (qfshandle_t* handle, qfileofs_t offs, int whence)
+{
+	qfileofs_t actual_pos;
+	if (!handle)
+		return -1;
+
+	switch (whence)
+	{
+	case SEEK_SET:
+		actual_pos = handle->start + offs;
+		break;
+	case SEEK_CUR:
+		actual_pos = handle->start + handle->offs + offs;
+		break;
+	case SEEK_END:
+		actual_pos = handle->filesize(handle) - handle->endtrim + offs;
+		break;
+	default:
+		return -1;
+	}
+	if (actual_pos < handle->start || actual_pos > handle->filesize(handle) - (handle->start + handle->endtrim))
+		return -1;
+	
+	if (handle->seek(handle, actual_pos) == 0)
+	{
+		handle->offs = actual_pos;
+		return 0;
+	}
+	return -1;
+}
+
+qfileofs_t QFS_Tell (qfshandle_t* handle)
+{
+	return handle ? handle->offs - handle->start : 0;
+}
+
+qboolean QFS_IgnoreBytes (qfshandle_t* handle, qfileofs_t cut, int whence)
+{
+	if (handle)
+	{
+		qfileofs_t filesize = handle->filesize(handle);
+		if (whence == SEEK_SET && cut <= filesize - handle->endtrim)
+			handle->start = cut;
+		else if (whence == SEEK_END && cut <= filesize - handle->start)
+			handle->endtrim = cut;
+		else if (whence == SEEK_SET && cut == 0)
+			handle->endtrim = handle->start = 0;
+		else
+			return false;
+		
+		if (handle->offs < handle->start)
+			return handle->seek (handle, handle->start) == 0;
+		if (handle->offs > handle->start - handle->endtrim)
+			return handle->seek (handle, filesize - handle->start - handle->endtrim) == 0;
+	}
+	return false;
+}
+
+char QFS_GetChar (qfshandle_t* handle, qboolean* eof_flag)
+{
+	char ch = '\0';
+	if (QFS_ReadFile (handle, &ch, 1) == 1)
+	{
+		if (eof_flag)
+			*eof_flag = false;
+		return ch;
+	}
+	if (eof_flag)
+		*eof_flag = true;
+	return '\0';
+}
+
+size_t QFS_GetLine (qfshandle_t* handle, char *buf, size_t bufsz)
+{
+	size_t i, o;
+	qboolean eof_flag = false;
+	if (bufsz < 1)
+		return 0;
+
+	for (i = 0, o = 0; o < bufsz - 1; ++i)
+	{
+		char ch = QFS_GetChar (handle, &eof_flag);
+		if (ch == '\n' || ch == '\0' || eof_flag)
+			break;
+		else if (ch != '\r')
+			buf[o++] = ch;
+	}
+
+	buf[o] = '\0';
+	return o;
+}
+

--- a/Quake/filesys.h
+++ b/Quake/filesys.h
@@ -1,0 +1,242 @@
+/*
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2002-2009 John Fitzgibbons and others
+Copyright (C) 2010-2014 QuakeSpasm developers
+Copyright (C) 2024-2024 ironwail developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+#ifndef QUAKE_FILESYSTEM_H
+#define QUAKE_FILESYSTEM_H
+
+//Opaque file handle that is used for Quake file system operations
+typedef struct file_handle_s qfshandle_t;
+
+/*
+===========
+QFS_OpenFile
+
+Attempts to open the requested file, returns NULL if it is not found.
+Filename never has a leading slash, but may contain directory walks
+
+Files opened with this will all use the same FILE* for the pack file
+===========
+*/
+qfshandle_t* QFS_OpenFile (const char* filename, unsigned int* path_id);
+
+/*
+===========
+QFS_FOpenFile
+
+If the requested file is inside a packfile, a new FILE* will be opened
+into the file pack. This can be a good idea if the file is used from
+another thread.
+===========
+*/
+qfshandle_t* QFS_FOpenFile (const char *filename, unsigned int *path_id);
+
+
+/*
+===========
+QFS_FileExists
+
+Returns whether the file is found in the quake filesystem.
+===========
+*/
+qboolean QFS_FileExists (const char *filename, unsigned int *path_id);
+
+/*
+============
+QFS_CloseFile
+
+Must be called when you are done with the file to free used resources
+============
+*/
+void QFS_CloseFile (qfshandle_t *handle);
+
+/*
+============
+QFS_ReadFile
+
+Read binary data from the file, returns the number of bytes read from the file.
+============
+*/
+size_t QFS_ReadFile (qfshandle_t* handle, void* buf, size_t size);
+
+/*
+============
+QFS_Eof
+
+Returns true if end of file has been reached on the handle
+============
+*/
+qboolean QFS_Eof (qfshandle_t* handle);
+
+/*
+============
+QFS_FileSize
+
+Returns the total size, in bytes, of the opened file.
+============
+*/
+qfileofs_t QFS_FileSize (qfshandle_t* handle);
+
+/*
+============
+QFS_Seek
+
+Move to a specific position in the file.
+whence can be one of SEEK_SET, SEEK_CUR, or SEEK_END and works like fseek in C.
+Like fseek, it returns 0 on success and -1 on failure.
+Unlike fseek, errno is not set on failure.
+
+When using .pk3 files this is a more expensive operation than .pak or regular files,
+especially when seeking backwards. For optimal results it is recommended to store
+already compressed music files without deflate compression inside pk3 files - in
+these cases the seek will be as efficient as a regular .pak file.
+============
+*/
+qfileofs_t QFS_Seek (qfshandle_t* handle, qfileofs_t offs, int whence);
+
+/*
+============
+QFS_Tell
+
+Determine the current seek position in the file.
+============
+*/
+qfileofs_t QFS_Tell (qfshandle_t* handle);
+
+/*
+============
+QFS_IgnoreBytes
+
+Specify a number of bytes that the file length should be shortened with.
+This could be useful for ignoring garbage at the end of a file such as id3 tags.
+
+whence can be either SEEK_END or SEEK_SET, SEEK_END will cut off at the end
+and SEEK_SET will cut off in the beginning.
+
+If the current file position is inside the removed area, the file cursor
+will be moved either to the beginning (SEEK_SET) or the end (SEEK_END)
+
+If you specify whence as SEEK_CUR and cut as 0, the ignore effect will be reset.
+============
+*/
+qboolean QFS_IgnoreBytes (qfshandle_t* handle, qfileofs_t cut, int whence);
+
+
+// these procedures open a file using COM_FindFile and loads it into a proper
+// buffer. the buffer is allocated with a total size of file size + 1. the
+// procedures differ by their buffer allocation method.
+// If you don't need the file size, you can give ldsize as NULL. 
+byte *QFS_LoadHunkFile (const char *path, unsigned int *path_id, size_t* ldsize);
+	// allocates the buffer on the hunk.
+byte *QFS_LoadMallocFile (const char *path, unsigned int *path_id, size_t* ldsize);
+	// allocates the buffer on the system mem (malloc).
+
+/*
+============
+QFS_LoadPackFile
+
+Load a pack file and return the id of the new pack
+============
+*/
+int QFS_LoadPackFile (const char *packfile);
+
+/*
+============
+QFS_FreePack
+
+Close handle and release all resources associated with the pack
+============
+*/
+void QFS_FreePack (int packid);
+
+/*
+============
+QFS_Shutdown
+
+Close all packs that are open
+============
+*/
+void QFS_Shutdown (void);
+
+/*
+============
+QFS_PackInfoName
+
+Returns the pack filename of the pack with the id or NULL if the pack doesn't exist
+============
+*/
+const char* QFS_PackInfoName (int packid);
+
+/*
+============
+QFS_PackInfoName
+
+Returns the number of files in the pack with the id or 0 if the pack doesn't exist
+============
+*/
+int QFS_PackInfoNumFiles (int packid);
+
+/*
+============
+QFS_PackInfoEntrySize
+
+Returns the total size, in bytes, of specified file index in the pack or 0 if it does not exist
+============
+*/
+qfileofs_t QFS_PackInfoEntrySize (int packid, int idx);
+
+/*
+============
+QFS_PackInfoEntryName
+
+Returns the file name, of the specified file index in the pack or NULL if it does not exist
+============
+*/
+const char* QFS_PackInfoEntryName (int packid, int idx);
+
+/*
+============
+QFS_GetChar
+
+Reads a single text character from the file. It is the basis
+for implementing other text mode read functions.
+returns 0 and sets eof_flag if there are no characters to read
+============
+*/
+char QFS_GetChar (qfshandle_t* handle, qboolean* eof_flag);
+
+/*
+============
+QFS_GetLine
+
+Reads a single line of text from the file. Returns the number of
+characters copied to buf. This will skip '\r' always.
+Newline '\n' is considered end of the line, '\n' will
+not be copied to buf.
+
+If buf is full before encountering '\n' the string will be truncated.
+The buf will always be NUL-terminated so it can at most
+extract bufsz-1 characters.
+============
+*/
+size_t QFS_GetLine (qfshandle_t* handle, char *buf, size_t bufsz);
+
+#endif 	/* QUAKE_FILESYSTEM_H */

--- a/Quake/gl_draw.c
+++ b/Quake/gl_draw.c
@@ -371,7 +371,7 @@ qpic_t	*Draw_TryCachePic (const char *path, unsigned int texflags)
 //
 // load the pic from disk
 //
-	dat = (qpic_t *)COM_LoadMallocFile (path, NULL);
+	dat = (qpic_t *)QFS_LoadMallocFile (path, NULL, NULL);
 	if (!dat)
 		return NULL;
 	SwapPic (dat);

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -379,7 +379,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 //
 // load the file
 //
-	buf = COM_LoadMallocFile (mod->name, &mod->path_id);
+	buf = QFS_LoadMallocFile (mod->name, &mod->path_id, NULL);
 	if (!buf)
 	{
 		if (crash)
@@ -854,6 +854,7 @@ static void Mod_LoadLighting (lump_t *l)
 	byte d, q64_b0, q64_b1;
 	char litfilename[MAX_OSPATH];
 	unsigned int path_id;
+	size_t filesize;
 
 	loadmodel->lightdata = NULL;
 	loadmodel->litfile = false;
@@ -862,7 +863,7 @@ static void Mod_LoadLighting (lump_t *l)
 	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
 	q_strlcat(litfilename, ".lit", sizeof(litfilename));
 	mark = Hunk_LowMark();
-	data = (byte*) COM_LoadHunkFile (litfilename, &path_id);
+	data = (byte*) QFS_LoadHunkFile (litfilename, &path_id, &filesize);
 	if (data)
 	{
 		// use lit file only from the same gamedir as the map
@@ -878,7 +879,7 @@ static void Mod_LoadLighting (lump_t *l)
 			i = LittleLong(((int *)data)[1]);
 			if (i == 1)
 			{
-				if (8+l->filelen*3 == com_filesize)
+				if (8+l->filelen*3 == (int)filesize)
 				{
 					Con_DPrintf2("%s loaded\n", litfilename);
 					loadmodel->lightdata = data + 8;
@@ -886,7 +887,7 @@ static void Mod_LoadLighting (lump_t *l)
 					return;
 				}
 				Hunk_FreeToLowMark(mark);
-				Con_Printf("Outdated .lit file (%s should be %u bytes, not %" SDL_PRIs64 "\n", litfilename, 8+l->filelen*3, com_filesize);
+				Con_Printf("Outdated .lit file (%s should be %" SDL_PRIs32 " bytes, not %" SDL_PRIu64 "\n", litfilename, 8+l->filelen*3, (uint64_t)filesize);
 			}
 			else
 			{
@@ -985,13 +986,13 @@ static void Mod_LoadEntities (lump_t *l)
 
 	q_snprintf(entfilename, sizeof(entfilename), "%s@%04x.ent", basemapname, crc);
 	Con_DPrintf2("trying to load %s\n", entfilename);
-	ents = (char *) COM_LoadHunkFile (entfilename, &path_id);
+	ents = (char *) QFS_LoadHunkFile (entfilename, &path_id, NULL);
 
 	if (!ents)
 	{
 		q_snprintf(entfilename, sizeof(entfilename), "%s.ent", basemapname);
 		Con_DPrintf2("trying to load %s\n", entfilename);
-		ents = (char *) COM_LoadHunkFile (entfilename, &path_id);
+		ents = (char *) QFS_LoadHunkFile (entfilename, &path_id, NULL);
 	}
 
 	if (ents)
@@ -2305,23 +2306,25 @@ typedef struct vispatch_s
 } vispatch_t;
 #define VISPATCH_HEADER_LEN 36
 
-static FILE *Mod_FindVisibilityExternal(void)
+static qfshandle_t *Mod_FindVisibilityExternal(void)
 {
 	vispatch_t header;
 	char visfilename[MAX_QPATH];
 	const char* shortname;
 	unsigned int path_id;
-	FILE *f;
+	qfshandle_t *f;
 	long pos;
 	size_t r;
 
 	q_snprintf(visfilename, sizeof(visfilename), "maps/%s.vis", loadname);
-	if (COM_FOpenFile(visfilename, &f, &path_id) < 0)
+	f = QFS_FOpenFile(visfilename, &path_id);
+	if (f == NULL)
 	{
 		Con_DPrintf("%s not found, trying ", visfilename);
 		q_snprintf(visfilename, sizeof(visfilename), "%s.vis", COM_SkipPath(com_gamedir));
 		Con_DPrintf("%s\n", visfilename);
-		if (COM_FOpenFile(visfilename, &f, &path_id) < 0)
+		f = QFS_FOpenFile(visfilename, &path_id);
+		if (f == NULL)
 		{
 			Con_DPrintf("external vis not found\n");
 			return NULL;
@@ -2329,7 +2332,7 @@ static FILE *Mod_FindVisibilityExternal(void)
 	}
 	if (path_id < loadmodel->path_id)
 	{
-		fclose(f);
+		QFS_CloseFile(f);
 		Con_DPrintf("ignored %s from a gamedir with lower priority\n", visfilename);
 		return NULL;
 	}
@@ -2338,20 +2341,20 @@ static FILE *Mod_FindVisibilityExternal(void)
 
 	shortname = COM_SkipPath(loadmodel->name);
 	pos = 0;
-	while ((r = fread(&header, 1, VISPATCH_HEADER_LEN, f)) == VISPATCH_HEADER_LEN)
+	while ((r = QFS_ReadFile(f, &header, VISPATCH_HEADER_LEN)) == VISPATCH_HEADER_LEN)
 	{
 		header.filelen = LittleLong(header.filelen);
 		if (header.filelen <= 0) {	/* bad entry -- don't trust the rest. */
-			fclose(f);
+			QFS_CloseFile(f);
 			return NULL;
 		}
 		if (!q_strcasecmp(header.mapname, shortname))
 			break;
 		pos += header.filelen + VISPATCH_HEADER_LEN;
-		fseek(f, pos, SEEK_SET);
+		QFS_Seek(f, pos, SEEK_SET);
 	}
 	if (r != VISPATCH_HEADER_LEN) {
-		fclose(f);
+		QFS_CloseFile(f);
 		Con_DPrintf("%s not found in %s\n", shortname, visfilename);
 		return NULL;
 	}
@@ -2359,20 +2362,20 @@ static FILE *Mod_FindVisibilityExternal(void)
 	return f;
 }
 
-static byte *Mod_LoadVisibilityExternal(FILE* f)
+static byte *Mod_LoadVisibilityExternal(qfshandle_t* f)
 {
-	int		mark, filelen;
+	int32_t	mark, filelen;
 	byte*	visdata;
 
 	filelen = 0;
-	if (fread(&filelen, 4, 1, f) != 1)
+	if (QFS_ReadFile(f, &filelen, 4) != 4)
 		return NULL;
 	filelen = LittleLong(filelen);
 	if (filelen <= 0) return NULL;
-	Con_DPrintf("...%d bytes visibility data\n", filelen);
+	Con_DPrintf("...%" SDL_PRIs32 " bytes visibility data\n", filelen);
 	mark = Hunk_LowMark ();
 	visdata = (byte *) Hunk_AllocNameNoFill (filelen, "EXT_VIS");
-	if (!fread(visdata, filelen, 1, f))
+	if (QFS_ReadFile(f, visdata, filelen) != (size_t)filelen)
 	{
 		Hunk_FreeToLowMark (mark);
 		return NULL;
@@ -2380,23 +2383,23 @@ static byte *Mod_LoadVisibilityExternal(FILE* f)
 	return visdata;
 }
 
-static void Mod_LoadLeafsExternal(FILE* f)
+static void Mod_LoadLeafsExternal(qfshandle_t* f)
 {
-	int		mark, filelen;
+	int32_t	mark, filelen;
 	void*	in;
 
 	filelen = 0;
-	if (fread(&filelen, 4, 1, f) != 1)
+	if (QFS_ReadFile(f, &filelen, 4) != 4)
 	{
 		Con_Warning ("Couldn't read external leaf data length\n");
 		return;
 	}
 	filelen = LittleLong(filelen);
 	if (filelen <= 0) return;
-	Con_DPrintf("...%d bytes leaf data\n", filelen);
+	Con_DPrintf("...%" SDL_PRIs32 " bytes leaf data\n", filelen);
 	mark = Hunk_LowMark ();
 	in = Hunk_AllocNameNoFill (filelen, "EXT_LEAF");
-	if (!fread(in, filelen, 1, f))
+	if (QFS_ReadFile(f, in, filelen) != (size_t)filelen)
 	{
 		Hunk_FreeToLowMark (mark);
 		return;
@@ -2462,7 +2465,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 
 	if (mod->bspversion == BSPVERSION && external_vis.value && sv.modelname[0] && !q_strcasecmp(loadname, sv.name))
 	{
-		FILE* fvis;
+		qfshandle_t* fvis;
 		Con_DPrintf("trying to open external vis file\n");
 		fvis = Mod_FindVisibilityExternal();
 		if (fvis) {
@@ -2474,7 +2477,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 			if (loadmodel->visdata) {
 				Mod_LoadLeafsExternal(fvis);
 			}
-			fclose(fvis);
+			QFS_CloseFile(fvis);
 			if (loadmodel->visdata && loadmodel->leafs && loadmodel->numleafs) {
 				goto visdone;
 			}
@@ -2622,7 +2625,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	char		buf[4 * 1024];
 	char		path[MAX_QPATH];
 	const char	*data;
-	FILE		*f;
+	qfshandle_t	*f;
 	lump_t		*entlump;
 	dheader_t	header;
 	int			i, filesize;
@@ -2635,17 +2638,18 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	if ((size_t) q_snprintf (path, sizeof (path), "maps/%s.bsp", map) >= sizeof (path))
 		return false;
 
-	filesize = COM_FOpenFile (path, &f, NULL);
+	f = QFS_FOpenFile(path, NULL);
+	filesize = f ? (int)QFS_FileSize(f) : -1;
 	if (filesize <= (int) sizeof (header))
 	{
 		if (filesize != -1)
-			fclose (f);
+			QFS_CloseFile (f);
 		return false;
 	}
 
-	if (fread (&header, sizeof (header), 1, f) != 1)
+	if (QFS_ReadFile (f, &header, sizeof (header)) != sizeof (header))
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2659,7 +2663,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	case BSPVERSION_QUAKE64:
 		break;
 	default:
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2670,7 +2674,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	if (entlump->filelen < 0 || entlump->filelen >= filesize ||
 		entlump->fileofs < 0 || entlump->fileofs + entlump->filelen > filesize)
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2682,9 +2686,9 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 		entlump->filelen = sizeof (buf) - 1;
 	}
 
-	fseek (f, entlump->fileofs - sizeof (header), SEEK_CUR);
-	i = fread (buf, 1, entlump->filelen, f);
-	fclose (f);
+	QFS_Seek (f, entlump->fileofs - sizeof (header), SEEK_CUR);
+	i = (int)QFS_ReadFile (f, buf, entlump->filelen);
+	QFS_CloseFile (f);
 
 	if (i <= 0)
 		return false;
@@ -3241,9 +3245,9 @@ qboolean loadMd5Replacement(qmodel_t* mod, char	*path)
 	COM_StripExtension (mod->name, path, MAX_QPATH);
 	COM_AddExtension (path, ".md5mesh", MAX_QPATH);
 
-	if (COM_FileExists (path, &md5_path_id) && md5_path_id >= mod->path_id)
+	if (QFS_FileExists (path, &md5_path_id) && md5_path_id >= mod->path_id)
 	{
-		char* md5buffer = (char*)COM_LoadMallocFile (path, NULL);
+		char* md5buffer = (char*)QFS_LoadMallocFile (path, NULL, NULL);
 		if (md5buffer)
 		{
 			Mod_LoadMD5MeshModel (mod, md5buffer);
@@ -3261,9 +3265,9 @@ qboolean loadMd3Replacement (qmodel_t* mod, char *path)
 	COM_StripExtension (mod->name, path, MAX_QPATH);
 	COM_AddExtension (path, ".md3", MAX_QPATH);
 
-	if (COM_FileExists (path, &md3_path_id) && md3_path_id >= mod->path_id)
+	if (QFS_FileExists (path, &md3_path_id) && md3_path_id >= mod->path_id)
 	{
-		char* md3buffer = (char*)COM_LoadMallocFile (path, NULL);
+		char* md3buffer = (char*)QFS_LoadMallocFile (path, NULL, NULL);
 		if (md3buffer)
 		{
 			Mod_LoadMD3Model (mod, md3buffer);
@@ -4045,7 +4049,7 @@ static void MD5Anim_Begin(md5animctx_t *ctx, const char *fname)
 	COM_StripExtension(fname, ctx->fname, sizeof(ctx->fname));
 	COM_AddExtension(ctx->fname, ".md5anim", sizeof(ctx->fname));
 	fname = ctx->fname;
-	ctx->animfile = (char *) COM_LoadMallocFile(fname, NULL);
+	ctx->animfile = (char *) QFS_LoadMallocFile(fname, NULL, NULL);
 	ctx->numposes = 0;
 
 	if (ctx->animfile)
@@ -4629,7 +4633,7 @@ static void Mod_LoadMD3_ValidateAndCacheSkinPath (int skinnum, int* valid_skin_p
 		return;
 
 	q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", md3path, skinnum);
-	skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+	skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 
 	if (skinbuffer) {
 		if (Mod_ValidateSkinFile (skinbuffer, md3_surface_names, num_md3_surfaces, skinpath)) {
@@ -4641,7 +4645,7 @@ static void Mod_LoadMD3_ValidateAndCacheSkinPath (int skinnum, int* valid_skin_p
 
 	if (valid_skin_path_id[skinnum] == 0) {
 		q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", basepath, skinnum);
-		skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+		skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 
 		if (skinbuffer) {
 			if (Mod_ValidateSkinFile (skinbuffer, md3_surface_names, num_md3_surfaces, skinpath)) {
@@ -4960,11 +4964,11 @@ static void Mod_LoadMD3Model (qmodel_t* mod, const char* buffer)
 			skinbuffer = NULL;
 			if (valid_skin_path_id[skinnum] == 1) {
 				q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", md3path, skinnum);
-				skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+				skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 			}
 			else if (valid_skin_path_id[skinnum] == 2) {
 				q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", basepath, skinnum);
-				skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+				skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 			}
 
 			if (!skinbuffer) {

--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -379,7 +379,7 @@ static qmodel_t *Mod_LoadModel (qmodel_t *mod, qboolean crash)
 //
 // load the file
 //
-	buf = COM_LoadMallocFile (mod->name, &mod->path_id);
+	buf = QFS_LoadMallocFile (mod->name, &mod->path_id, NULL);
 	if (!buf)
 	{
 		if (crash)
@@ -854,6 +854,7 @@ static void Mod_LoadLighting (lump_t *l)
 	byte d, q64_b0, q64_b1;
 	char litfilename[MAX_OSPATH];
 	unsigned int path_id;
+	size_t filesize;
 
 	loadmodel->lightdata = NULL;
 	loadmodel->litfile = false;
@@ -862,7 +863,7 @@ static void Mod_LoadLighting (lump_t *l)
 	COM_StripExtension(litfilename, litfilename, sizeof(litfilename));
 	q_strlcat(litfilename, ".lit", sizeof(litfilename));
 	mark = Hunk_LowMark();
-	data = (byte*) COM_LoadHunkFile (litfilename, &path_id);
+	data = (byte*) QFS_LoadHunkFile (litfilename, &path_id, &filesize);
 	if (data)
 	{
 		// use lit file only from the same gamedir as the map
@@ -878,7 +879,7 @@ static void Mod_LoadLighting (lump_t *l)
 			i = LittleLong(((int *)data)[1]);
 			if (i == 1)
 			{
-				if (8+l->filelen*3 == com_filesize)
+				if (8+l->filelen*3 == (int)filesize)
 				{
 					Con_DPrintf2("%s loaded\n", litfilename);
 					loadmodel->lightdata = data + 8;
@@ -886,7 +887,7 @@ static void Mod_LoadLighting (lump_t *l)
 					return;
 				}
 				Hunk_FreeToLowMark(mark);
-				Con_Printf("Outdated .lit file (%s should be %u bytes, not %" SDL_PRIs64 "\n", litfilename, 8+l->filelen*3, com_filesize);
+				Con_Printf("Outdated .lit file (%s should be %" SDL_PRIs32 " bytes, not %" SDL_PRIu64 "\n", litfilename, 8+l->filelen*3, (uint64_t)filesize);
 			}
 			else
 			{
@@ -985,13 +986,13 @@ static void Mod_LoadEntities (lump_t *l)
 
 	q_snprintf(entfilename, sizeof(entfilename), "%s@%04x.ent", basemapname, crc);
 	Con_DPrintf2("trying to load %s\n", entfilename);
-	ents = (char *) COM_LoadHunkFile (entfilename, &path_id);
+	ents = (char *) QFS_LoadHunkFile (entfilename, &path_id, NULL);
 
 	if (!ents)
 	{
 		q_snprintf(entfilename, sizeof(entfilename), "%s.ent", basemapname);
 		Con_DPrintf2("trying to load %s\n", entfilename);
-		ents = (char *) COM_LoadHunkFile (entfilename, &path_id);
+		ents = (char *) QFS_LoadHunkFile (entfilename, &path_id, NULL);
 	}
 
 	if (ents)
@@ -2305,23 +2306,25 @@ typedef struct vispatch_s
 } vispatch_t;
 #define VISPATCH_HEADER_LEN 36
 
-static FILE *Mod_FindVisibilityExternal(void)
+static qfshandle_t *Mod_FindVisibilityExternal(void)
 {
 	vispatch_t header;
 	char visfilename[MAX_QPATH];
 	const char* shortname;
 	unsigned int path_id;
-	FILE *f;
+	qfshandle_t *f;
 	long pos;
 	size_t r;
 
 	q_snprintf(visfilename, sizeof(visfilename), "maps/%s.vis", loadname);
-	if (COM_FOpenFile(visfilename, &f, &path_id) < 0)
+	f = QFS_FOpenFile(visfilename, &path_id);
+	if (f == NULL)
 	{
 		Con_DPrintf("%s not found, trying ", visfilename);
 		q_snprintf(visfilename, sizeof(visfilename), "%s.vis", COM_SkipPath(com_gamedir));
 		Con_DPrintf("%s\n", visfilename);
-		if (COM_FOpenFile(visfilename, &f, &path_id) < 0)
+		f = QFS_FOpenFile(visfilename, &path_id);
+		if (f == NULL)
 		{
 			Con_DPrintf("external vis not found\n");
 			return NULL;
@@ -2329,7 +2332,7 @@ static FILE *Mod_FindVisibilityExternal(void)
 	}
 	if (path_id < loadmodel->path_id)
 	{
-		fclose(f);
+		QFS_CloseFile(f);
 		Con_DPrintf("ignored %s from a gamedir with lower priority\n", visfilename);
 		return NULL;
 	}
@@ -2338,20 +2341,20 @@ static FILE *Mod_FindVisibilityExternal(void)
 
 	shortname = COM_SkipPath(loadmodel->name);
 	pos = 0;
-	while ((r = fread(&header, 1, VISPATCH_HEADER_LEN, f)) == VISPATCH_HEADER_LEN)
+	while ((r = QFS_ReadFile(f, &header, VISPATCH_HEADER_LEN)) == VISPATCH_HEADER_LEN)
 	{
 		header.filelen = LittleLong(header.filelen);
 		if (header.filelen <= 0) {	/* bad entry -- don't trust the rest. */
-			fclose(f);
+			QFS_CloseFile(f);
 			return NULL;
 		}
 		if (!q_strcasecmp(header.mapname, shortname))
 			break;
 		pos += header.filelen + VISPATCH_HEADER_LEN;
-		fseek(f, pos, SEEK_SET);
+		QFS_Seek(f, pos, SEEK_SET);
 	}
 	if (r != VISPATCH_HEADER_LEN) {
-		fclose(f);
+		QFS_CloseFile(f);
 		Con_DPrintf("%s not found in %s\n", shortname, visfilename);
 		return NULL;
 	}
@@ -2359,20 +2362,20 @@ static FILE *Mod_FindVisibilityExternal(void)
 	return f;
 }
 
-static byte *Mod_LoadVisibilityExternal(FILE* f)
+static byte *Mod_LoadVisibilityExternal(qfshandle_t* f)
 {
-	int		mark, filelen;
+	int32_t	mark, filelen;
 	byte*	visdata;
 
 	filelen = 0;
-	if (fread(&filelen, 4, 1, f) != 1)
+	if (QFS_ReadFile(f, &filelen, 4) != 4)
 		return NULL;
 	filelen = LittleLong(filelen);
 	if (filelen <= 0) return NULL;
-	Con_DPrintf("...%d bytes visibility data\n", filelen);
+	Con_DPrintf("...%" SDL_PRIs32 " bytes visibility data\n", filelen);
 	mark = Hunk_LowMark ();
 	visdata = (byte *) Hunk_AllocNameNoFill (filelen, "EXT_VIS");
-	if (!fread(visdata, filelen, 1, f))
+	if (QFS_ReadFile(f, visdata, filelen) != (size_t)filelen)
 	{
 		Hunk_FreeToLowMark (mark);
 		return NULL;
@@ -2380,23 +2383,23 @@ static byte *Mod_LoadVisibilityExternal(FILE* f)
 	return visdata;
 }
 
-static void Mod_LoadLeafsExternal(FILE* f)
+static void Mod_LoadLeafsExternal(qfshandle_t* f)
 {
-	int		mark, filelen;
+	int32_t	mark, filelen;
 	void*	in;
 
 	filelen = 0;
-	if (fread(&filelen, 4, 1, f) != 1)
+	if (QFS_ReadFile(f, &filelen, 4) != 4)
 	{
 		Con_Warning ("Couldn't read external leaf data length\n");
 		return;
 	}
 	filelen = LittleLong(filelen);
 	if (filelen <= 0) return;
-	Con_DPrintf("...%d bytes leaf data\n", filelen);
+	Con_DPrintf("...%" SDL_PRIs32 " bytes leaf data\n", filelen);
 	mark = Hunk_LowMark ();
 	in = Hunk_AllocNameNoFill (filelen, "EXT_LEAF");
-	if (!fread(in, filelen, 1, f))
+	if (QFS_ReadFile(f, in, filelen) != (size_t)filelen)
 	{
 		Hunk_FreeToLowMark (mark);
 		return;
@@ -2462,7 +2465,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 
 	if (mod->bspversion == BSPVERSION && external_vis.value && sv.modelname[0] && !q_strcasecmp(loadname, sv.name))
 	{
-		FILE* fvis;
+		qfshandle_t* fvis;
 		Con_DPrintf("trying to open external vis file\n");
 		fvis = Mod_FindVisibilityExternal();
 		if (fvis) {
@@ -2474,7 +2477,7 @@ static void Mod_LoadBrushModel (qmodel_t *mod, void *buffer)
 			if (loadmodel->visdata) {
 				Mod_LoadLeafsExternal(fvis);
 			}
-			fclose(fvis);
+			QFS_CloseFile(fvis);
 			if (loadmodel->visdata && loadmodel->leafs && loadmodel->numleafs) {
 				goto visdone;
 			}
@@ -2622,7 +2625,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	char		buf[4 * 1024];
 	char		path[MAX_QPATH];
 	const char	*data;
-	FILE		*f;
+	qfshandle_t	*f;
 	lump_t		*entlump;
 	dheader_t	header;
 	int			i, filesize;
@@ -2635,17 +2638,18 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	if ((size_t) q_snprintf (path, sizeof (path), "maps/%s.bsp", map) >= sizeof (path))
 		return false;
 
-	filesize = COM_FOpenFile (path, &f, NULL);
+	f = QFS_FOpenFile(path, NULL);
+	filesize = f ? (int)QFS_FileSize(f) : -1;
 	if (filesize <= (int) sizeof (header))
 	{
 		if (filesize != -1)
-			fclose (f);
+			QFS_CloseFile (f);
 		return false;
 	}
 
-	if (fread (&header, sizeof (header), 1, f) != 1)
+	if (QFS_ReadFile (f, &header, sizeof (header)) != sizeof (header))
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2659,7 +2663,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	case BSPVERSION_QUAKE64:
 		break;
 	default:
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2670,7 +2674,7 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 	if (entlump->filelen < 0 || entlump->filelen >= filesize ||
 		entlump->fileofs < 0 || entlump->fileofs + entlump->filelen > filesize)
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return false;
 	}
 
@@ -2682,9 +2686,9 @@ qboolean Mod_LoadMapDescription (char *desc, size_t maxchars, const char *map)
 		entlump->filelen = sizeof (buf) - 1;
 	}
 
-	fseek (f, entlump->fileofs - sizeof (header), SEEK_CUR);
-	i = fread (buf, 1, entlump->filelen, f);
-	fclose (f);
+	QFS_Seek (f, entlump->fileofs - sizeof (header), SEEK_CUR);
+	i = (int)QFS_ReadFile (f, buf, entlump->filelen);
+	QFS_CloseFile (f);
 
 	if (i <= 0)
 		return false;
@@ -3241,9 +3245,9 @@ qboolean loadMd5Replacement(qmodel_t* mod, char	*path)
 	COM_StripExtension (mod->name, path, MAX_QPATH);
 	COM_AddExtension (path, ".md5mesh", MAX_QPATH);
 
-	if (COM_FileExists (path, &md5_path_id) && md5_path_id >= mod->path_id)
+	if (QFS_FileExists (path, &md5_path_id) && md5_path_id >= mod->path_id)
 	{
-		char* md5buffer = (char*)COM_LoadMallocFile (path, NULL);
+		char* md5buffer = (char*)QFS_LoadMallocFile (path, NULL, NULL);
 		if (md5buffer)
 		{
 			qboolean result = Mod_LoadMD5MeshModel (mod, md5buffer);
@@ -3261,9 +3265,9 @@ qboolean loadMd3Replacement (qmodel_t* mod, char *path)
 	COM_StripExtension (mod->name, path, MAX_QPATH);
 	COM_AddExtension (path, ".md3", MAX_QPATH);
 
-	if (COM_FileExists (path, &md3_path_id) && md3_path_id >= mod->path_id)
+	if (QFS_FileExists (path, &md3_path_id) && md3_path_id >= mod->path_id)
 	{
-		char* md3buffer = (char*)COM_LoadMallocFile (path, NULL);
+		char* md3buffer = (char*)QFS_LoadMallocFile (path, NULL, NULL);
 		if (md3buffer)
 		{
 			Mod_LoadMD3Model (mod, md3buffer);
@@ -4045,7 +4049,7 @@ static qboolean MD5Anim_Begin(md5animctx_t *ctx, const char *fname)
 	COM_StripExtension(fname, ctx->fname, sizeof(ctx->fname));
 	COM_AddExtension(ctx->fname, ".md5anim", sizeof(ctx->fname));
 	fname = ctx->fname;
-	ctx->animfile = (char *) COM_LoadMallocFile(fname, NULL);
+	ctx->animfile = (char *) QFS_LoadMallocFile(fname, NULL, NULL);
 	ctx->numposes = 0;
 
 	if (ctx->animfile)
@@ -4671,7 +4675,7 @@ static void Mod_LoadMD3_ValidateAndCacheSkinPath (int skinnum, int* valid_skin_p
 		return;
 
 	q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", md3path, skinnum);
-	skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+	skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 
 	if (skinbuffer) {
 		if (Mod_ValidateSkinFile (skinbuffer, md3_surface_names, num_md3_surfaces, skinpath)) {
@@ -4683,7 +4687,7 @@ static void Mod_LoadMD3_ValidateAndCacheSkinPath (int skinnum, int* valid_skin_p
 
 	if (valid_skin_path_id[skinnum] == 0) {
 		q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", basepath, skinnum);
-		skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+		skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 
 		if (skinbuffer) {
 			if (Mod_ValidateSkinFile (skinbuffer, md3_surface_names, num_md3_surfaces, skinpath)) {
@@ -5002,11 +5006,11 @@ static void Mod_LoadMD3Model (qmodel_t* mod, const char* buffer)
 			skinbuffer = NULL;
 			if (valid_skin_path_id[skinnum] == 1) {
 				q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", md3path, skinnum);
-				skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+				skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 			}
 			else if (valid_skin_path_id[skinnum] == 2) {
 				q_snprintf (skinpath, sizeof (skinpath), "%s_%d.skin", basepath, skinnum);
-				skinbuffer = (char*)COM_LoadMallocFile (skinpath, NULL);
+				skinbuffer = (char*)QFS_LoadMallocFile (skinpath, NULL, NULL);
 			}
 
 			if (!skinbuffer) {

--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -1754,11 +1754,12 @@ R_ReadPointFile_f
 */
 void R_ReadPointFile_f (void)
 {
-	FILE		*f;
+	qfshandle_t	*f;
 	vec3_t		org;
 	int			r, n;
 	qboolean	leakmode;
 	char		name[MAX_QPATH];
+	char		rdbuf[256];
 
 	VEC_CLEAR (r_pointfile);
 
@@ -1768,7 +1769,7 @@ void R_ReadPointFile_f (void)
 	q_snprintf (name, sizeof(name), "maps/%s.pts", cl.mapname);
 	leakmode = Cmd_Argc () >= 2 && !strcmp (Cmd_Argv (1), "leak");
 
-	COM_FOpenFile (name, &f, NULL);
+	f = QFS_FOpenFile (name, NULL);
 	if (!f)
 	{
 		Con_Printf ("couldn't open %s\n", name);
@@ -1779,8 +1780,14 @@ void R_ReadPointFile_f (void)
 		Con_Printf ("Reading %s...\n", name);
 	org[0] = org[1] = org[2] = 0; // silence pesky compiler warnings
 
-	for (r = 0; fscanf (f,"%f %f %f\n", &org[0], &org[1], &org[2]) == 3; r++)
+	for (r = 0; !QFS_Eof (f); ++r)
 	{
+		memset(rdbuf, 0, sizeof(rdbuf));
+		QFS_GetLine (f, rdbuf, sizeof(rdbuf));
+
+		if (sscanf (rdbuf, "%f %f %f", &org[0], &org[1], &org[2]) != 3)
+			break;
+
 		Vec_Append ((void **) &r_pointfile, sizeof (r_pointfile[0]), &org, 1);
 		n = (int) VEC_SIZE (r_pointfile);
 		if (n >= 3 && Collinear (r_pointfile[n-3], r_pointfile[n-2], r_pointfile[n-1]))
@@ -1790,7 +1797,7 @@ void R_ReadPointFile_f (void)
 		}
 	}
 
-	fclose (f);
+	QFS_CloseFile (f);
 
 	if (leakmode)
 		Con_Warning ("map appears to have leaks!\n");

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -531,7 +531,7 @@ void R_NewMap (void)
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)
-		if (!cl.worldmodel->visdata && COM_FileExists (va ("maps/%s.pts", cl.mapname), NULL))
+		if (!cl.worldmodel->visdata && QFS_FileExists (va ("maps/%s.pts", cl.mapname), NULL))
 			Cbuf_AddText ("pointfile leak\n");
 }
 

--- a/Quake/gl_rmisc.c
+++ b/Quake/gl_rmisc.c
@@ -533,7 +533,7 @@ void R_NewMap (void)
 
 	// Load pointfile if map has no vis data and either developer mode is on or the game was started from a map editing tool
 	if (developer.value || map_checks.value)
-		if (!cl.worldmodel->visdata && COM_FileExists (va ("maps/%s.pts", cl.mapname), NULL))
+		if (!cl.worldmodel->visdata && QFS_FileExists (va ("maps/%s.pts", cl.mapname), NULL))
 			Cbuf_AddText ("pointfile leak\n");
 }
 

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -894,8 +894,7 @@ void SCR_DrawDemoControls (void)
 
 	// Approximate the fraction of the demo that's already been played back
 	// based on the current file offset and total demo size
-	// Note: we need to take into account the starting offset for pak files
-	frac = (Sys_ftell (cls.demofile) - cls.demofilestart) / (double)cls.demofilesize;
+	frac = QFS_Tell (cls.inpdemo) / (double)cls.demofilesize;
 	frac = CLAMP (0.f, frac, 1.f);
 
 	if (cl.intermission)

--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -913,8 +913,7 @@ static void SCR_DrawDemoControls (void)
 
 	// Approximate the fraction of the demo that's already been played back
 	// based on the current file offset and total demo size
-	// Note: we need to take into account the starting offset for pak files
-	frac = (Sys_ftell (cls.demofile) - cls.demofilestart) / (double)cls.demofilesize;
+	frac = QFS_Tell (cls.inpdemo) / (double)cls.demofilesize;
 	frac = CLAMP (0.f, frac, 1.f);
 
 	if (cl.intermission)

--- a/Quake/gl_sky.c
+++ b/Quake/gl_sky.c
@@ -215,7 +215,7 @@ static void Skywind_Load_f (void)
 	}
 
 	q_snprintf (relname, sizeof (relname), "gfx/env/%s" SKYWIND_CFG, skybox->name);
-	buf = (char *) COM_LoadMallocFile (relname, NULL);
+	buf = (char *) QFS_LoadMallocFile (relname, NULL, NULL);
 	if (!buf)
 	{
 		Con_DPrintf ("Sky wind config not found '%s'.\n", relname);

--- a/Quake/gl_texmgr.c
+++ b/Quake/gl_texmgr.c
@@ -736,25 +736,25 @@ void TexMgr_LoadPalette (void)
 {
 	byte *pal, *src, *colormap;
 	int i, j, mark, numfb;
-	FILE *f;
+	qfshandle_t *f;
 
-	COM_FOpenFile ("gfx/palette.lmp", &f, NULL);
+	f = QFS_FOpenFile ("gfx/palette.lmp", NULL);
 	if (!f)
 		Sys_Error ("Couldn't load gfx/palette.lmp");
 
 	mark = Hunk_LowMark ();
 	pal = (byte *) Hunk_AllocNoFill (768);
-	if (fread (pal, 768, 1, f) != 1)
+	if (QFS_ReadFile (f, pal, 768) != 768)
 		Sys_Error ("Failed reading gfx/palette.lmp");
-	fclose(f);
+	QFS_CloseFile(f);
 
-	COM_FOpenFile ("gfx/colormap.lmp", &f, NULL);
+	f = QFS_FOpenFile ("gfx/colormap.lmp", NULL);
 	if (!f)
 		Sys_Error ("Couldn't load gfx/colormap.lmp");
 	colormap = (byte *) Hunk_AllocNoFill (256 * 64);
-	if (fread (colormap, 256 * 64, 1, f) != 1)
+	if (QFS_ReadFile (f, colormap, 256 * 64) != 256 * 64)
 		Sys_Error ("TexMgr_LoadPalette: colormap read error");
-	fclose(f);
+	QFS_CloseFile(f);
 
 	//find fullbright colors
 	memset (is_fullbright, 0, sizeof (is_fullbright));
@@ -1619,11 +1619,11 @@ void TexMgr_ReloadImage (gltexture_t *glt, int shirt, int pants)
 
 	if (glt->source_file[0] && glt->source_offset) {
 		//lump inside file
-		FILE *f;
+		qfshandle_t *f;
 		int sz;
-		COM_FOpenFile(glt->source_file, &f, NULL);
+		f = QFS_FOpenFile(glt->source_file, NULL);
 		if (!f) goto invalid;
-		fseek (f, glt->source_offset, SEEK_CUR);
+		QFS_Seek (f, glt->source_offset, SEEK_CUR);
 		size = glt->source_width * glt->source_height;
 		/* should be SRC_INDEXED, but no harm being paranoid:  */
 		if (glt->source_format == SRC_RGBA) {
@@ -1633,8 +1633,8 @@ void TexMgr_ReloadImage (gltexture_t *glt, int shirt, int pants)
 			size *= lightmap_bytes;
 		}
 		data = (byte *) Hunk_AllocNoFill (size);
-		sz = (int) fread (data, 1, size, f);
-		fclose (f);
+		sz = (int) QFS_ReadFile (f, data, size);
+		QFS_CloseFile (f);
 		if (sz != size) {
 			Hunk_FreeToLowMark(mark);
 			Host_Error("Read error for %s", glt->name);

--- a/Quake/gl_vidsdl.c
+++ b/Quake/gl_vidsdl.c
@@ -1558,6 +1558,11 @@ static void VID_InitModelist (void)
 	}
 }
 
+static const char* config_names[] =
+{
+	CONFIG_NAME, "config.cfg"
+};
+
 /*
 ===================
 VID_Init
@@ -1570,6 +1575,7 @@ void	VID_Init (void)
 	int		display_width, display_height, display_refreshrate;
 	qboolean	fullscreen;
 	cmd_function_t	*cmd;
+	size_t idxcfg;
 	const char	*read_vars[] =
 	{
 		"vid_fullscreen",
@@ -1585,7 +1591,6 @@ void	VID_Init (void)
 		"r_softemu_metric",
 		"scr_pixelaspect",
 	};
-#define num_readvars	Q_COUNTOF(read_vars)
 
 	Con_SafePrintf ("\nVideo initialization\n");
 
@@ -1649,12 +1654,16 @@ void	VID_Init (void)
 	Cvar_SetValueQuick (&vid_height, (float)display_height);
 	Cvar_SetValueQuick (&vid_refreshrate, (float)display_refreshrate);
 
-	if (CFG_OpenConfig(CONFIG_NAME) == 0 || CFG_OpenConfig("config.cfg") == 0)
+	for (idxcfg = 0; idxcfg < Q_COUNTOF(config_names); ++idxcfg)
 	{
-		CFG_ReadCvars(read_vars, num_readvars);
-		CFG_CloseConfig();
+		if (QFS_FileExists (config_names[idxcfg], NULL))
+		{
+			CFG_ReadCvars (config_names[idxcfg], read_vars, Q_COUNTOF(read_vars));
+			break;
+		}
 	}
-	CFG_ReadCvarOverrides(read_vars, num_readvars);
+
+	CFG_ReadCvarOverrides(read_vars, Q_COUNTOF(read_vars));
 
 	VID_InitModelist();
 	VID_InitMouseCursors();

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1416,7 +1416,7 @@ void Host_Init (void)
 
 	if (cls.state != ca_dedicated)
 	{
-		host_colormap = (byte *)COM_LoadHunkFile ("gfx/colormap.lmp", NULL);
+		host_colormap = (byte *)QFS_LoadHunkFile ("gfx/colormap.lmp", NULL, NULL);
 		if (!host_colormap)
 			Sys_Error ("Couldn't load gfx/colormap.lmp");
 
@@ -1510,6 +1510,8 @@ void Host_Shutdown(void)
 	Modlist_ShutDown ();
 
 	NET_Shutdown ();
+
+	QFS_Shutdown();
 
 	if (cls.state != ca_dedicated)
 	{

--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1416,7 +1416,7 @@ void Host_Init (void)
 
 	if (cls.state != ca_dedicated)
 	{
-		host_colormap = (byte *)COM_LoadHunkFile ("gfx/colormap.lmp", NULL);
+		host_colormap = (byte *)QFS_LoadHunkFile ("gfx/colormap.lmp", NULL, NULL);
 		if (!host_colormap)
 			Sys_Error ("Couldn't load gfx/colormap.lmp");
 
@@ -1512,6 +1512,8 @@ void Host_Shutdown(void)
 	Modlist_ShutDown ();
 
 	NET_Shutdown ();
+
+	QFS_Shutdown();
 
 	if (cls.state != ca_dedicated)
 	{

--- a/Quake/host_cmd.c
+++ b/Quake/host_cmd.c
@@ -442,7 +442,6 @@ void ExtraMaps_Init (void)
 	char			mapname[32];
 	char			ignorepakdir[32];
 	searchpath_t	*search;
-	pack_t			*pak;
 	int				i;
 
 	// we don't want to list the maps in id1 pakfiles,
@@ -467,15 +466,19 @@ void ExtraMaps_Init (void)
 		}
 		else //pakfile
 		{
-			qboolean isbase = (strstr(search->pack->filename, ignorepakdir) != NULL);
-			for (i = 0, pak = search->pack; i < pak->numfiles; i++)
+			const char* pack_filename = QFS_PackInfoName(search->pack);
+			qboolean isbase = (pack_filename && strstr(pack_filename, ignorepakdir) != NULL);
+			int filecnt = QFS_PackInfoNumFiles(search->pack);
+			for (i = 0; i < filecnt; ++i)
 			{
-				if (pak->files[i].filelen > 32*1024 &&				// don't list files under 32k (ammo boxes etc)
-					!strncmp (pak->files[i].name, "maps/", 5) &&	// don't list files outside of maps/
-					!strchr (pak->files[i].name + 5, '/') &&		// don't list files in subdirectories
-					!strcmp (COM_FileGetExtension (pak->files[i].name), "bsp"))
+				const char* entry_filename = QFS_PackInfoEntryName(search->pack, i);
+				if (entry_filename &&
+					QFS_PackInfoEntrySize(search->pack, i) > 32*1024 &&				// don't list files under 32k (ammo boxes etc)
+					!strncmp (entry_filename, "maps/", 5) &&	// don't list files outside of maps/
+					!strchr (entry_filename + 5, '/') &&		// don't list files in subdirectories
+					!strcmp (COM_FileGetExtension (entry_filename), "bsp"))
 				{
-					COM_StripExtension (pak->files[i].name + 5, mapname, sizeof (mapname));
+					COM_StripExtension (entry_filename + 5, mapname, sizeof (mapname));
 					ExtraMaps_Add (mapname, isbase ? NULL : search);
 				}
 			}
@@ -1139,7 +1142,7 @@ static void Modlist_Add (const char *name)
 	// look for mapdb.json file
 	if (!info->full_name)
 	{
-		char *mapdb = (char *) COM_LoadMallocFile ("mapdb.json", &path_id);
+		char *mapdb = (char *) QFS_LoadMallocFile ("mapdb.json", &path_id, NULL);
 		if (mapdb)
 		{
 			qboolean is_base_mapdb = !com_searchpaths || path_id < com_searchpaths->path_id;
@@ -1205,6 +1208,10 @@ static qboolean Modlist_Check (const char *modname, const char *base)
 	q_snprintf (modpath, sizeof (modpath), "%s/%s", base, modname);
 
 	q_snprintf (itempath, sizeof (itempath), "%s/pak0.pak", modpath);
+	if (Sys_FileExists (itempath))
+		return true;
+	
+	q_snprintf (itempath, sizeof (itempath), "%s/pak0.pk3", modpath);
 	if (Sys_FileExists (itempath))
 		return true;
 
@@ -1349,7 +1356,6 @@ void DemoList_Init (void)
 	char		demname[32];
 	char		ignorepakdir[32];
 	searchpath_t	*search;
-	pack_t		*pak;
 	int		i;
 
 	// we don't want to list the demos in id1 pakfiles,
@@ -1371,13 +1377,16 @@ void DemoList_Init (void)
 		}
 		else //pakfile
 		{
-			if (!strstr(search->pack->filename, ignorepakdir))
+			const char* pack_filename = QFS_PackInfoName(search->pack);
+			if (!strstr(pack_filename, ignorepakdir))
 			{ //don't list standard id demos
-				for (i = 0, pak = search->pack; i < pak->numfiles; i++)
+				int filecnt = QFS_PackInfoNumFiles(search->pack);
+				for (i = 0; i < filecnt; ++i)
 				{
-					if (!strcmp (COM_FileGetExtension (pak->files[i].name), "dem"))
+					const char* entry_filename = QFS_PackInfoEntryName(search->pack, i);
+					if (!strcmp (COM_FileGetExtension (entry_filename), "dem"))
 					{
-						COM_StripExtension (pak->files[i].name, demname, sizeof (demname));
+						COM_StripExtension (entry_filename, demname, sizeof (demname));
 						FileList_Add (demname, &demolist);
 					}
 				}
@@ -1508,7 +1517,6 @@ static void SkyList_AddDirRec (const char *root, const char *relpath)
 void SkyList_Init (void)
 {
 	searchpath_t	*search;
-	pack_t			*pak;
 	int				i;
 
 	for (search = com_searchpaths; search; search = search->next)
@@ -1516,8 +1524,11 @@ void SkyList_Init (void)
 		if (*search->filename) //directory
 			SkyList_AddDirRec (search->filename, "gfx/env");
 		else //pakfile
-			for (i = 0, pak = search->pack; i < pak->numfiles; i++)
-				SkyList_AddFile (pak->files[i].name);
+		{
+			int entry_count = QFS_PackInfoNumFiles(search->pack);
+			for (i = 0; i < entry_count; ++i)
+				SkyList_AddFile (QFS_PackInfoEntryName(search->pack, i));
+		}
 	}
 }
 
@@ -2107,7 +2118,7 @@ static void Host_Changelevel_f (void)
 
 	//johnfitz -- check for client having map before anything else
 	q_snprintf (level, sizeof(level), "maps/%s.bsp", Cmd_Argv(1));
-	if (!COM_FileExists(level, NULL))
+	if (!QFS_FileExists(level, NULL))
 		Host_Error ("cannot find map %s", level);
 	//johnfitz
 

--- a/Quake/image.c
+++ b/Quake/image.c
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "quakedef.h"
 
-static byte *Image_LoadPCX (FILE *f, int *width, int *height);
-static byte *Image_LoadLMP (FILE *f, int *width, int *height);
+static byte *Image_LoadPCX (qfshandle_t *f, int *width, int *height);
+static byte *Image_LoadLMP (qfshandle_t *f, int *width, int *height);
 
 #ifdef __GNUC__
 	// Suppress unused function warnings on GCC/clang
@@ -67,32 +67,32 @@ static byte *Image_LoadLMP (FILE *f, int *width, int *height);
 
 static char loadfilename[MAX_OSPATH]; //file scope so that error messages can use it
 
-typedef struct stdio_buffer_s {
-	FILE *f;
+typedef struct io_buffer_s {
+	qfshandle_t *f;
 	unsigned char buffer[1024];
-	int size;
-	int pos;
-} stdio_buffer_t;
+	size_t size;
+	size_t pos;
+} io_buffer_t;
 
-static stdio_buffer_t *Buf_Alloc(FILE *f)
+static io_buffer_t *Buf_Alloc(qfshandle_t *f)
 {
-	stdio_buffer_t *buf = (stdio_buffer_t *) calloc(1, sizeof(stdio_buffer_t));
+	io_buffer_t *buf = (io_buffer_t *) calloc(1, sizeof(io_buffer_t));
 	if (!buf)
 		Sys_Error ("Buf_Alloc: out of memory");
 	buf->f = f;
 	return buf;
 }
 
-static void Buf_Free(stdio_buffer_t *buf)
+static void Buf_Free(io_buffer_t *buf)
 {
 	free(buf);
 }
 
-static inline int Buf_GetC(stdio_buffer_t *buf)
+static inline int Buf_GetC(io_buffer_t *buf)
 {
 	if (buf->pos >= buf->size)
 	{
-		buf->size = fread(buf->buffer, 1, sizeof(buf->buffer), buf->f);
+		buf->size = QFS_ReadFile(buf->f, buf->buffer, sizeof(buf->buffer));
 		buf->pos = 0;
 		
 		if (buf->size == 0)
@@ -100,6 +100,25 @@ static inline int Buf_GetC(stdio_buffer_t *buf)
 	}
 
 	return buf->buffer[buf->pos++];
+}
+
+/*
+Callback functions that stb can use to read from QFS files
+*/
+
+static int STBCB_Read(void *f, char *data, int size)
+{
+	return (int)QFS_ReadFile((qfshandle_t*)f, data, (size_t)size);
+}
+
+static void STBCB_Skip(void *f, int n)
+{
+	QFS_Seek((qfshandle_t*)f, (qfileofs_t)n, SEEK_CUR);
+}
+
+static int STBCB_Eof(void* f)
+{
+	return QFS_Eof((qfshandle_t*)f) ? 1 : 0;
 }
 
 /*
@@ -112,17 +131,22 @@ returns a pointer to hunk allocated RGBA data
 byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat *fmt)
 {
 	static const char *const stbi_formats[] = {"png", "tga", "jpg", NULL};
-	FILE	*f;
+	qfshandle_t	*f;
+	stbi_io_callbacks callbacks;
 	int		i;
 
 	for (i = 0; stbi_formats[i]; i++)
 	{
 		const char *ext = stbi_formats[i];
 		q_snprintf (loadfilename, sizeof(loadfilename), "%s.%s", name, ext);
-		COM_FOpenFile (loadfilename, &f, NULL);
+		f = QFS_FOpenFile (loadfilename, NULL);
 		if (f)
 		{
-			byte *data = stbi_load_from_file (f, width, height, NULL, 4);
+			callbacks.read = &STBCB_Read;
+			callbacks.skip = &STBCB_Skip;
+			callbacks.eof = &STBCB_Eof;
+
+			byte *data = stbi_load_from_callbacks (&callbacks, f, width, height, NULL, 4);
 			if (data)
 			{
 				int numbytes = (*width) * (*height) * 4;
@@ -136,13 +160,13 @@ byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat
 			}
 			else
 				Con_Warning ("couldn't load %s (%s)\n", loadfilename, stbi_failure_reason ());
-			fclose (f);
+			QFS_CloseFile (f);
 			return data;
 		}
 	}
 
 	q_snprintf (loadfilename, sizeof(loadfilename), "%s.pcx", name);
-	COM_FOpenFile (loadfilename, &f, NULL);
+	f = QFS_FOpenFile (loadfilename, NULL);
 	if (f)
 	{
 		*fmt = SRC_RGBA;
@@ -150,7 +174,7 @@ byte *Image_LoadImage (const char *name, int *width, int *height, enum srcformat
 	}
 
 	q_snprintf (loadfilename, sizeof(loadfilename), "%s.lmp", name);
-	COM_FOpenFile (loadfilename, &f, NULL);
+	f = QFS_FOpenFile (loadfilename, NULL);
 	if (f)
 	{
 		*fmt = SRC_INDEXED;
@@ -247,17 +271,15 @@ typedef struct
 Image_LoadPCX
 ============
 */
-static byte *Image_LoadPCX (FILE *f, int *width, int *height)
+static byte *Image_LoadPCX (qfshandle_t *f, int *width, int *height)
 {
 	pcxheader_t	pcx;
-	int			x, y, w, h, readbyte, runlength, start;
+	int			x, y, w, h, readbyte, runlength;
 	byte		*p, *data;
 	byte		palette[768];
-	stdio_buffer_t  *buf;
+	io_buffer_t  *buf;
 
-	start = ftell (f); //save start of file (since we might be inside a pak file, SEEK_SET might not be the start of the pcx)
-
-	if (fread(&pcx, sizeof(pcx), 1, f) != 1)
+	if (QFS_ReadFile(f, &pcx, sizeof(pcx)) != sizeof(pcx))
 		Sys_Error ("Failed reading header from '%s'", loadfilename);
 
 	pcx.xmin = (unsigned short)LittleShort (pcx.xmin);
@@ -281,12 +303,14 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 	data = (byte *) Hunk_AllocNoFill ((w*h+1)*4); //+1 to allow reading padding byte on last line
 
 	//load palette
-	fseek (f, start + com_filesize - 768, SEEK_SET);
-	if (fread (palette, 768, 1, f) != 1)
+	if (QFS_Seek (f, QFS_FileSize(f) - sizeof(palette), SEEK_SET) != 0
+		|| QFS_ReadFile (f, palette, sizeof(palette)) != sizeof(palette))
+	{
 		Sys_Error ("Failed reading palette from '%s'", loadfilename);
+	}
 
 	//back to start of image data
-	fseek (f, start + sizeof(pcx), SEEK_SET);
+	QFS_Seek (f, sizeof(pcx), SEEK_SET);
 
 	buf = Buf_Alloc(f);
 
@@ -319,7 +343,7 @@ static byte *Image_LoadPCX (FILE *f, int *width, int *height)
 	}
 
 	Buf_Free(buf);
-	fclose(f);
+	QFS_CloseFile(f);
 
 	*width = w;
 	*height = h;
@@ -342,16 +366,16 @@ typedef struct
 Image_LoadLMP
 ============
 */
-static byte *Image_LoadLMP (FILE *f, int *width, int *height)
+static byte *Image_LoadLMP (qfshandle_t *f, int *width, int *height)
 {
 	lmpheader_t	qpic;
 	size_t		pix;
 	int			mark;
 	void		*data;
 
-	if (fread (&qpic, sizeof(qpic), 1, f) != 1)
+	if (QFS_ReadFile (f, &qpic, sizeof(qpic)) != sizeof(qpic))
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return NULL;
 	}
 	qpic.width = LittleLong (qpic.width);
@@ -359,21 +383,21 @@ static byte *Image_LoadLMP (FILE *f, int *width, int *height)
 
 	pix = qpic.width*qpic.height;
 
-	if (com_filesize != sizeof (qpic) + pix)
+	if (QFS_FileSize(f) != (qfileofs_t)(sizeof (qpic) + pix))
 	{
-		fclose (f);
+		QFS_CloseFile (f);
 		return NULL;
 	}
 
 	mark = Hunk_LowMark ();
 	data = (byte *) Hunk_AllocNoFill (pix);
-	if (fread (data, 1, pix, f) != pix)
+	if (QFS_ReadFile (f, data, pix) != pix)
 	{
 		Hunk_FreeToLowMark (mark);
-		fclose (f);
+		QFS_CloseFile (f);
 		return NULL;
 	}
-	fclose (f);
+	QFS_CloseFile (f);
 
 	*width = qpic.width;
 	*height = qpic.height;

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -5173,7 +5173,7 @@ void M_Menu_Keys_f (void)
 	VEC_CLEAR (keysmenu.custom_items);
 
 	// load custom items from bindlist.lst
-	file = (char*) COM_LoadMallocFile ("bindlist.lst", NULL);
+	file = (char*) QFS_LoadMallocFile ("bindlist.lst", NULL, NULL);
 	if (file)
 	{
 		char *text = file;
@@ -7720,20 +7720,22 @@ void M_ConfigureNetSubsystem(void)
 static qboolean M_CheckCustomGfx (const char *custompath, const char *basepath, int knownlength, const unsigned int *hashes, int numhashes)
 {
 	unsigned int id_custom, id_base;
-	int h, length;
+	qfshandle_t* h;
+	int length;
 	qboolean ret = false;
 
-	if (!COM_FileExists (custompath, &id_custom))
+	if (!QFS_FileExists (custompath, &id_custom))
 		return false;
 
-	length = COM_OpenFile (basepath, &h, &id_base);
+	h = QFS_OpenFile (basepath, &id_base);
+	length = (int)QFS_FileSize (h);
 	if (id_custom >= id_base)
 		ret = true;
 	else if (length == knownlength)
 	{
 		int mark = Hunk_LowMark ();
 		byte* data = (byte*) Hunk_Alloc (length);
-		if (length == Sys_FileRead (h, data, length))
+		if (length == (int)QFS_ReadFile (h, data, length))
 		{
 			unsigned int hash = COM_HashBlock (data, length);
 			while (numhashes-- > 0 && !ret)
@@ -7743,7 +7745,7 @@ static qboolean M_CheckCustomGfx (const char *custompath, const char *basepath, 
 		Hunk_FreeToLowMark (mark);
 	}
 
-	COM_CloseFile (h);
+	QFS_CloseFile (h);
 
 	return ret;
 }

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -5149,7 +5149,7 @@ static void M_Keys_LoadBindList (void)
 	}
 	VEC_CLEAR (keysmenu.custom_items);
 
-	file = (char*) COM_LoadMallocFile ("bindlist.lst", NULL);
+	file = (char*) QFS_LoadMallocFile ("bindlist.lst", NULL, NULL);
 	if (file)
 	{
 		uint32_t missing_mask[BITARRAY_DWORDS (Q_COUNTOF (default_keybinds))];
@@ -7742,20 +7742,22 @@ void M_ConfigureNetSubsystem(void)
 static qboolean M_CheckCustomGfx (const char *custompath, const char *basepath, int knownlength, const unsigned int *hashes, int numhashes)
 {
 	unsigned int id_custom, id_base;
-	int h, length;
+	qfshandle_t* h;
+	int length;
 	qboolean ret = false;
 
-	if (!COM_FileExists (custompath, &id_custom))
+	if (!QFS_FileExists (custompath, &id_custom))
 		return false;
 
-	length = COM_OpenFile (basepath, &h, &id_base);
+	h = QFS_OpenFile (basepath, &id_base);
+	length = (int)QFS_FileSize (h);
 	if (id_custom >= id_base)
 		ret = true;
 	else if (length == knownlength)
 	{
 		int mark = Hunk_LowMark ();
 		byte* data = (byte*) Hunk_Alloc (length);
-		if (length == Sys_FileRead (h, data, length))
+		if (length == (int)QFS_ReadFile (h, data, length))
 		{
 			unsigned int hash = COM_HashBlock (data, length);
 			while (numhashes-- > 0 && !ret)
@@ -7765,7 +7767,7 @@ static qboolean M_CheckCustomGfx (const char *custompath, const char *basepath, 
 		Hunk_FreeToLowMark (mark);
 	}
 
-	COM_CloseFile (h);
+	QFS_CloseFile (h);
 
 	return ret;
 }

--- a/Quake/miniz.c
+++ b/Quake/miniz.c
@@ -2247,7 +2247,7 @@ mz_bool mz_zip_end(mz_zip_archive *pZip)
 
     return MZ_FALSE;
 }
-
+#endif /* unused */
 mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, char *pFilename, mz_uint filename_buf_size)
 {
     mz_uint n;
@@ -2268,7 +2268,6 @@ mz_uint mz_zip_reader_get_filename(mz_zip_archive *pZip, mz_uint file_index, cha
     }
     return n + 1;
 }
-#endif /* unused */
 
 mz_bool mz_zip_reader_file_stat(mz_zip_archive *pZip, mz_uint file_index, mz_zip_archive_file_stat *pStat)
 {

--- a/Quake/pr_edict.c
+++ b/Quake/pr_edict.c
@@ -2098,15 +2098,16 @@ PR_LoadProgs
 qboolean PR_LoadProgs (const char *filename, qboolean fatal)
 {
 	int			i;
+	size_t		filesize;
 
 	PR_ClearProgs(qcvm);	//just in case.
 
-	qcvm->progs = (dprograms_t *)COM_LoadHunkFile (filename, NULL);
+	qcvm->progs = (dprograms_t *)QFS_LoadHunkFile (filename, NULL, &filesize);
 	if (!qcvm->progs)
 		return false;
-	Con_DPrintf ("Programs occupy %" SDL_PRIs64 "K.\n", com_filesize/1024);
+	Con_DPrintf ("Programs occupy %" SDL_PRIs64 "K.\n", (int64_t)(filesize/1024));
 
-	qcvm->crc = CRC_Block (qcvm->progs, com_filesize);
+	qcvm->crc = CRC_Block (qcvm->progs, filesize);
 
 	// byte swap the header
 	for (i = 0; i < (int) sizeof(*qcvm->progs) / 4; i++)
@@ -2164,7 +2165,7 @@ qboolean PR_LoadProgs (const char *filename, qboolean fatal)
 
 	qcvm->functions = (dfunction_t *)((byte *)qcvm->progs + qcvm->progs->ofs_functions);
 	qcvm->strings = (char *)qcvm->progs + qcvm->progs->ofs_strings;
-	if (qcvm->progs->ofs_strings + qcvm->progs->numstrings >= com_filesize)
+	if (qcvm->progs->ofs_strings + qcvm->progs->numstrings >= (int64_t)filesize)
 		Host_Error ("progs.dat strings go past end of file\n");
 
 	// initialize the strings

--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -242,6 +242,7 @@ typedef struct
 
 #include "sys.h"
 #include "common.h"
+#include "filesys.h"
 #include "bspfile.h"
 #include "zone.h"
 #include "mathlib.h"

--- a/Quake/snd_codec.c
+++ b/Quake/snd_codec.c
@@ -293,14 +293,10 @@ int S_CodecReadStream (snd_stream_t *stream, int bytes, void *buffer)
 snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec, qboolean loop)
 {
 	snd_stream_t *stream;
-	FILE *handle;
-	qboolean pak;
-	long length;
 
 	/* Try to open the file */
-	length = (long) COM_FOpenFile(filename, &handle, NULL);
-	pak = file_from_pak;
-	if (length == -1)
+	qfshandle_t* handle = QFS_FOpenFile(filename, NULL);
+	if (handle == NULL)
 	{
 		Con_DPrintf("Couldn't open %s\n", filename);
 		return NULL;
@@ -310,11 +306,7 @@ snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec, qboolean
 	stream = (snd_stream_t *) Z_Malloc(sizeof(snd_stream_t));
 	stream->codec = codec;
 	stream->loop = loop;
-	stream->fh.file = handle;
-	stream->fh.start = ftell(handle);
-	stream->fh.pos = 0;
-	stream->fh.length = length;
-	stream->fh.pak = stream->pak = pak;
+	stream->fh = handle;
 	q_strlcpy(stream->name, filename, MAX_QPATH);
 
 	return stream;
@@ -322,7 +314,7 @@ snd_stream_t *S_CodecUtilOpen(const char *filename, snd_codec_t *codec, qboolean
 
 void S_CodecUtilClose(snd_stream_t **stream)
 {
-	fclose((*stream)->fh.file);
+	QFS_CloseFile((*stream)->fh);
 	Z_Free(*stream);
 	*stream = NULL;
 }

--- a/Quake/snd_codec.h
+++ b/Quake/snd_codec.h
@@ -48,8 +48,7 @@ typedef struct snd_codec_s snd_codec_t;
 
 typedef struct snd_stream_s
 {
-	fshandle_t fh;
-	qboolean pak;
+	qfshandle_t *fh;
 	char name[MAX_QPATH];	/* name of the source file */
 	snd_info_t info;
 	stream_status_t status;

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -99,6 +99,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 	wavinfo_t	info;
 	int		len;
 	float	stepscale;
+	size_t	filesize;
 	sfxcache_t	*sc;
 
 // see if still in memory
@@ -114,7 +115,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 
 //	Con_Printf ("loading %s\n",namebuffer);
 
-	data = COM_LoadMallocFile (namebuffer, NULL);
+	data = QFS_LoadMallocFile (namebuffer, NULL, &filesize);
 
 	if (!data)
 	{
@@ -122,7 +123,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 		return NULL;
 	}
 
-	info = GetWavinfo (s->name, data, com_filesize);
+	info = GetWavinfo (s->name, data, filesize);
 	if (info.channels != 1)
 	{
 		free (data);

--- a/Quake/snd_modplug.c
+++ b/Quake/snd_modplug.c
@@ -61,13 +61,13 @@ static qboolean S_MODPLUG_CodecOpenStream (snd_stream_t *stream)
 {
 /* need to load the whole file into memory and pass it to libmodplug */
 	byte *moddata;
-	long len;
+	qfileofs_t len;
 	int mark;
 
-	len = FS_filelength (&stream->fh);
+	len = QFS_FileSize (stream->fh);
 	mark = Hunk_LowMark();
 	moddata = (byte *) Hunk_Alloc(len);
-	FS_fread(moddata, 1, len, &stream->fh);
+	QFS_ReadFile(stream->fh, moddata, len);
 
 	S_MODPLUG_SetSettings(stream);
 	stream->priv = ModPlug_Load(moddata, len);

--- a/Quake/snd_mpg123.c
+++ b/Quake/snd_mpg123.c
@@ -43,17 +43,14 @@ typedef struct _mp3_priv_t
 /* CALLBACKS: libmpg123 expects POSIX read/lseek() behavior! */
 static ssize_t mp3_read (void *f, void *buf, size_t size)
 {
-	ssize_t ret = (ssize_t) FS_fread(buf, 1, size, (fshandle_t *)f);
-	if (ret == 0 && errno != 0)
-		return -1;
-	return ret;
+	return (ssize_t) QFS_ReadFile((qfshandle_t*)f,  buf, size);
 }
 static off_t mp3_seek (void *f, off_t offset, int whence)
 {
 	if (f == NULL) return -1;
-	if (FS_fseek((fshandle_t *)f, (long) offset, whence) < 0)
+	if (QFS_Seek((qfshandle_t *)f, (qfileofs_t) offset, whence) < 0)
 		return (off_t)-1;
-	return (off_t) FS_ftell((fshandle_t *)f);
+	return (off_t) QFS_Tell((qfshandle_t *)f);
 }
 
 static qboolean S_MP3_CodecInitialize (void)
@@ -101,7 +98,7 @@ static qboolean S_MP3_CodecOpenStream (snd_stream_t *stream)
 	}
 
 	if (mpg123_replace_reader_handle(priv->handle, mp3_read, mp3_seek, NULL) != MPG123_OK ||
-	    mpg123_open_handle(priv->handle, &stream->fh) != MPG123_OK)
+	    mpg123_open_handle(priv->handle, stream->fh) != MPG123_OK)
 	{
 		Con_Printf("Unable to open mpg123 handle\n");
 		goto _fail;

--- a/Quake/snd_opus.c
+++ b/Quake/snd_opus.c
@@ -41,29 +41,24 @@ static int opc_fclose (void *f)
 
 static int opc_fread (void *f, unsigned char *buf, int size)
 {
-	int ret;
-
 	if (size < 0)
 	{
 		errno = EINVAL;
 		return -1;
 	}
 
-	ret = (int) FS_fread(buf, 1, (size_t)size, (fshandle_t *)f);
-	if (ret == 0 && errno != 0)
-		ret = -1;
-	return ret;
+	return (int) QFS_ReadFile((qfshandle_t*)f, buf, (size_t)size);
 }
 
 static int opc_fseek (void *f, opus_int64 off, int whence)
 {
 	if (f == NULL) return (-1);
-	return FS_fseek((fshandle_t *)f, (long) off, whence);
+	return QFS_Seek((qfshandle_t*)f, (long) off, whence);
 }
 
 static opus_int64 opc_ftell (void *f)
 {
-	return (opus_int64) FS_ftell((fshandle_t *)f);
+	return (opus_int64) QFS_Tell((qfshandle_t *)f);
 }
 
 static const OpusFileCallbacks opc_qfs =
@@ -90,7 +85,7 @@ static qboolean S_OPUS_CodecOpenStream (snd_stream_t *stream)
 	long numstreams;
 	int res;
 
-	opFile = op_open_callbacks(&stream->fh, &opc_qfs, NULL, 0, &res);
+	opFile = op_open_callbacks(stream->fh, &opc_qfs, NULL, 0, &res);
 	if (!opFile)
 	{
 		Con_Printf("%s is not a valid Opus file (error %i).\n",

--- a/Quake/snd_wave.c
+++ b/Quake/snd_wave.c
@@ -34,10 +34,10 @@
 FGetLittleLong
 =================
 */
-static int FGetLittleLong (FILE *f, qboolean *ok)
+static int32_t FGetLittleLong (qfshandle_t *f, qboolean *ok)
 {
-	int		v;
-	*ok &= fread(&v, sizeof(v), 1, f) == 1;
+	int32_t v;
+	*ok &= QFS_ReadFile(f, &v, sizeof(v)) == sizeof(v);
 	return LittleLong(v);
 }
 
@@ -46,10 +46,10 @@ static int FGetLittleLong (FILE *f, qboolean *ok)
 FGetLittleShort
 =================
 */
-static short FGetLittleShort(FILE *f, qboolean *ok)
+static short FGetLittleShort(qfshandle_t *f, qboolean *ok)
 {
-	short	v;
-	*ok &= fread(&v, sizeof(v), 1, f) == 1;
+	int16_t v;
+	*ok &= QFS_ReadFile(f, &v, sizeof(v)) == sizeof(v);
 	return LittleShort(v);
 }
 
@@ -58,14 +58,14 @@ static short FGetLittleShort(FILE *f, qboolean *ok)
 WAV_ReadChunkInfo
 =================
 */
-static int WAV_ReadChunkInfo(FILE *f, char *name)
+static int WAV_ReadChunkInfo(qfshandle_t *f, char *name)
 {
 	int len, r;
 	qboolean ok = true;
 
 	name[4] = 0;
 
-	r = fread(name, 1, 4, f);
+	r = QFS_ReadFile(f, name, 4);
 	if (r != 4)
 		return -1;
 
@@ -92,7 +92,7 @@ WAV_FindRIFFChunk
 Returns the length of the data in the chunk, or -1 if not found
 =================
 */
-static int WAV_FindRIFFChunk(FILE *f, const char *chunk)
+static int WAV_FindRIFFChunk(qfshandle_t *f, const char *chunk)
 {
 	char	name[5];
 	int		len;
@@ -105,7 +105,7 @@ static int WAV_FindRIFFChunk(FILE *f, const char *chunk)
 		len = ((len + 1) & ~1);	/* pad by 2 . */
 
 		/* Not the right chunk - skip it */
-		fseek(f, len, SEEK_CUR);
+		QFS_Seek(f, len, SEEK_CUR);
 	}
 
 	return -1;
@@ -116,14 +116,14 @@ static int WAV_FindRIFFChunk(FILE *f, const char *chunk)
 WAV_ReadRIFFHeader
 =================
 */
-static qboolean WAV_ReadRIFFHeader(const char *name, FILE *file, snd_info_t *info)
+static qboolean WAV_ReadRIFFHeader(const char *name, qfshandle_t *file, snd_info_t *info)
 {
 	char dump[16];
 	int wav_format;
 	int fmtlen = 0;
 	qboolean ok = true;
 
-	if (fread(dump, 1, 12, file) < 12 ||
+	if (QFS_ReadFile(file, dump, 12) < 12 ||
 	    strncmp(dump, "RIFF", 4) != 0 ||
 	    strncmp(&dump[8], "WAVE", 4) != 0)
 	{
@@ -170,7 +170,7 @@ static qboolean WAV_ReadRIFFHeader(const char *name, FILE *file, snd_info_t *inf
 	if (fmtlen > 16)
 	{
 		fmtlen -= 16;
-		fseek(file, fmtlen, SEEK_CUR);
+		QFS_Seek(file, fmtlen, SEEK_CUR);
 	}
 
 	/* Scan for the data chunk */
@@ -203,17 +203,12 @@ S_WAV_CodecOpenStream
 */
 static qboolean S_WAV_CodecOpenStream(snd_stream_t *stream)
 {
-	long start = stream->fh.start;
-
 	/* Read the RIFF header */
-	/* The file reads are sequential, therefore no need
-	 * for the FS_*() functions: We will manipulate the
-	 * file by ourselves from now on. */
-	if (!WAV_ReadRIFFHeader(stream->name, stream->fh.file, &stream->info))
+
+	if (!WAV_ReadRIFFHeader(stream->name, stream->fh, &stream->info))
 		return false;
 
-	stream->fh.start = ftell(stream->fh.file); /* reset to data position */
-	if (stream->fh.start - start + stream->info.size > stream->fh.length)
+	if (QFS_Tell(stream->fh) + stream->info.size > QFS_FileSize(stream->fh))
 	{
 		Con_Printf("%s data size mismatch\n", stream->name);
 		return false;
@@ -229,15 +224,15 @@ S_WAV_CodecReadStream
 */
 int S_WAV_CodecReadStream(snd_stream_t *stream, int bytes, void *buffer)
 {
-	int remaining = stream->info.size - stream->fh.pos;
+	int remaining = stream->info.size - (int)QFS_Tell(stream->fh);
 	int i, samples;
 
 	if (remaining <= 0)
 		return 0;
 	if (bytes > remaining)
 		bytes = remaining;
-	stream->fh.pos += bytes;
-	if (fread(buffer, 1, bytes, stream->fh.file) != bytes)
+
+	if (QFS_ReadFile(stream->fh, buffer, bytes) != (qfileofs_t)bytes)
 		Sys_Error ("S_WAV_CodecReadStream: read error on %d bytes (%s)", bytes, stream->name);
 	if (stream->info.width == 2)
 	{
@@ -255,7 +250,7 @@ static void S_WAV_CodecCloseStream (snd_stream_t *stream)
 
 static int S_WAV_CodecRewindStream (snd_stream_t *stream)
 {
-	FS_rewind(&stream->fh);
+	QFS_Seek(stream->fh, 0, SEEK_SET);
 	return 0;
 }
 

--- a/Quake/sv_main.c
+++ b/Quake/sv_main.c
@@ -1784,7 +1784,7 @@ static void SV_PrintMapChecklist (void)
 	{
 		char pointfile[MAX_OSPATH];
 		q_snprintf (pointfile, sizeof (pointfile), "maps/%s.pts", sv.name);
-		if (COM_FileExists (pointfile, NULL))
+		if (QFS_FileExists (pointfile, NULL))
 			SV_PrintMapCheck (MAPCHECK_FAILED, "vis data (unsealed map?)");
 		else
 			SV_PrintMapCheck (MAPCHECK_FAILED, "vis data");

--- a/Quake/sys.h
+++ b/Quake/sys.h
@@ -72,23 +72,13 @@ qboolean Sys_Explore (const char *path);
 
 typedef int64_t qfileofs_t;
 
-// returns the file size or -1 if file is not present.
-// the file should be in BINARY mode for stupid OSs that care
-qfileofs_t Sys_FileOpenRead (const char *path, int *hndl);
-
-// Returns a file handle
-int Sys_FileOpenWrite (const char *path);
-
-void Sys_FileClose (int handle);
-void Sys_FileSeek (int handle, int position);
-int Sys_FileRead (int handle, void *dest, int count);
-int Sys_FileWrite (int handle,const void *data, int count);
 qboolean Sys_FileExists (const char *path);
 qboolean Sys_GetFileTime (const char *path, time_t *out);
 void Sys_mkdir (const char *path);
 FILE *Sys_fopen (const char *path, const char *mode);
 int Sys_fseek (FILE *file, qfileofs_t ofs, int origin);
 qfileofs_t Sys_ftell (FILE *file);
+qfileofs_t Sys_filelength (FILE *f);
 int Sys_remove (const char *path);
 int Sys_rename (const char *oldname, const char *newname);
 

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -53,24 +53,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 qboolean		isDedicated;
 
-#define	MAX_HANDLES		32	/* johnfitz -- was 10 */
-static FILE		*sys_handles[MAX_HANDLES];
 static qboolean		stdinIsATTY;	/* from ioquake3 source */
 
 static double rcp_counter_freq;
-
-static int findhandle (void)
-{
-	int i;
-
-	for (i = 1; i < MAX_HANDLES; i++)
-	{
-		if (!sys_handles[i])
-			return i;
-	}
-	Sys_Error ("out of handles");
-	return -1;
-}
 
 FILE *Sys_fopen (const char *path, const char *mode)
 {
@@ -132,66 +117,6 @@ qfileofs_t Sys_filelength (FILE *f)
 	Sys_fseek (f, pos, SEEK_SET);
 
 	return end;
-}
-
-qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
-{
-	FILE		*f;
-	int			i;
-	qfileofs_t	retval;
-
-	i = findhandle ();
-	f = fopen(path, "rb");
-
-	if (!f)
-	{
-		*hndl = -1;
-		retval = -1;
-	}
-	else
-	{
-		sys_handles[i] = f;
-		*hndl = i;
-		retval = Sys_filelength(f);
-	}
-
-	return retval;
-}
-
-int Sys_FileOpenWrite (const char *path)
-{
-	FILE	*f;
-	int		i;
-
-	i = findhandle ();
-	f = Sys_fopen(path, "wb");
-
-	if (!f)
-		Sys_Error ("Error opening %s: %s", path, strerror(errno));
-
-	sys_handles[i] = f;
-	return i;
-}
-
-void Sys_FileClose (int handle)
-{
-	fclose (sys_handles[handle]);
-	sys_handles[handle] = NULL;
-}
-
-void Sys_FileSeek (int handle, int position)
-{
-	fseek (sys_handles[handle], position, SEEK_SET);
-}
-
-int Sys_FileRead (int handle, void *dest, int count)
-{
-	return fread (dest, 1, count, sys_handles[handle]);
-}
-
-int Sys_FileWrite (int handle, const void *data, int count)
-{
-	return fwrite (data, 1, count, sys_handles[handle]);
 }
 
 qboolean Sys_FileExists (const char *path)

--- a/Quake/sys_sdl_win.c
+++ b/Quake/sys_sdl_win.c
@@ -68,23 +68,7 @@ qboolean		isDedicated;
 
 static HANDLE		hinput, houtput;
 
-#define	MAX_HANDLES		32	/* johnfitz -- was 10 */
-static FILE		*sys_handles[MAX_HANDLES];
-
 static double rcp_counter_freq;
-
-static int findhandle (void)
-{
-	int i;
-
-	for (i = 1; i < MAX_HANDLES; i++)
-	{
-		if (!sys_handles[i])
-			return i;
-	}
-	Sys_Error ("out of handles");
-	return -1;
-}
 
 static void UTF8ToWideString (const char *src, wchar_t *dst, size_t maxchars)
 {
@@ -185,66 +169,6 @@ qfileofs_t Sys_filelength (FILE *f)
 	Sys_fseek (f, pos, SEEK_SET);
 
 	return end;
-}
-
-qfileofs_t Sys_FileOpenRead (const char *path, int *hndl)
-{
-	FILE		*f;
-	int			i;
-	qfileofs_t	retval;
-
-	i = findhandle ();
-	f = Sys_fopen (path, "rb");
-
-	if (!f)
-	{
-		*hndl = -1;
-		retval = -1;
-	}
-	else
-	{
-		sys_handles[i] = f;
-		*hndl = i;
-		retval = Sys_filelength(f);
-	}
-
-	return retval;
-}
-
-int Sys_FileOpenWrite (const char *path)
-{
-	FILE	*f;
-	int		i;
-
-	i = findhandle ();
-	f = Sys_fopen (path, "wb");
-
-	if (!f)
-		Sys_Error ("Error opening %s: %s", path, strerror(errno));
-
-	sys_handles[i] = f;
-	return i;
-}
-
-void Sys_FileClose (int handle)
-{
-	fclose (sys_handles[handle]);
-	sys_handles[handle] = NULL;
-}
-
-void Sys_FileSeek (int handle, int position)
-{
-	fseek (sys_handles[handle], position, SEEK_SET);
-}
-
-int Sys_FileRead (int handle, void *dest, int count)
-{
-	return fread (dest, 1, count, sys_handles[handle]);
-}
-
-int Sys_FileWrite (int handle, const void *data, int count)
-{
-	return fwrite (data, 1, count, sys_handles[handle]);
 }
 
 #ifndef INVALID_FILE_ATTRIBUTES

--- a/Quake/wad.c
+++ b/Quake/wad.c
@@ -77,7 +77,7 @@ void W_LoadWadFile (void) //johnfitz -- filename is now hard-coded for honesty
 	//TODO: use cache_alloc
 	if (wad_base)
 		free (wad_base);
-	wad_base = COM_LoadMallocFile (filename, NULL);
+	wad_base = QFS_LoadMallocFile (filename, NULL, NULL);
 	if (!wad_base)
 		Sys_Error ("W_LoadWadFile: couldn't load %s\n\n"
 			   "Basedir is: %s\n\n"

--- a/Windows/VisualStudio/ironwail.vcxproj
+++ b/Windows/VisualStudio/ironwail.vcxproj
@@ -237,6 +237,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClCompile Include="..\..\Quake\console.c" />
     <ClCompile Include="..\..\Quake\crc.c" />
     <ClCompile Include="..\..\Quake\cvar.c" />
+    <ClCompile Include="..\..\Quake\filesys.c" />
     <ClCompile Include="..\..\Quake\gl_draw.c" />
     <ClCompile Include="..\..\Quake\gl_fog.c" />
     <ClCompile Include="..\..\Quake\gl_mesh.c" />
@@ -363,6 +364,7 @@ copy "$(SolutionDir)..\zlib\$(PlatformShortName)\*.dll" "$(TargetDir)"</Command>
     <ClInclude Include="..\..\Quake\crc.h" />
     <ClInclude Include="..\..\Quake\cvar.h" />
     <ClInclude Include="..\..\Quake\draw.h" />
+    <ClInclude Include="..\..\Quake\filesys.h" />
     <ClInclude Include="..\..\Quake\glquake.h" />
     <ClInclude Include="..\..\Quake\gl_model.h" />
     <ClInclude Include="..\..\Quake\gl_shaders.h" />

--- a/Windows/VisualStudio/ironwail.vcxproj.filters
+++ b/Windows/VisualStudio/ironwail.vcxproj.filters
@@ -270,6 +270,9 @@
     <ClCompile Include="..\..\Quake\snd_mpg123.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Quake\filesys.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Quake\anorm_dots.h">
@@ -480,6 +483,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Quake\jsmn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Quake\filesys.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This implements a new file system abstraction for game data that should be easier to understand and follow than the workarounds that have accumulated over the years. The main reason for this refactoring is to enable easy implementation of other pack formats than PAK. More specifically, this adds pk3 support.

Access to game data in **packs** and **on disk** is now done through the QFS_* functions in filesys.h/filesys.c. The old file system functions dealing with this have been removed. Some functions from common.c were moved to filesys.c and renamed to begin with QFS_ rather than COM_ for consistency. The game search path handling remains in common.c.

## PK3 Support
Should resolve issue #4. Support for PK3 files is implemented, and this is done using the existing **miniz.c** that was already included in the source tree, so no new dependencies are introduced.

Decompression is done "on the fly", meaning no temporary files with extracted data are created. It doesn't just slurp the entire file into memory from the pk3 file either, so memory usage should not become an issue even for large files.

## Good to know
If a game folder has both **pakN.pak** and **pakN.pk3** with the same number, the pak file will be used and the pk3 file ignored. This one I wasn't quite sure of - it seems the most backward compatible way, but if you want it to work some other way just let me know and I'll change it.

The function **Sys_FileOpenRead** which opened .PAK files and sometimes other files had a limitation of at most 32 simultaneously opened handles (10 before FitzQuake). Not sure what this was all about, but my guess it that this limit was originally supposed to be for the number of open **packs**. There is now just a limit of 32 open packs.

Music files requires more seeking back and forth inside the file than other file usage. In compressed pk3 packs, this operation is a bit more expensive CPU wise. For optimal results, already compressed music files could be stored as uncompressed data inside the pk3 file - but it's probably not a big deal either way, I didn't experience any noticeable ill effects while playing music from compressed data inside pk3 files.

Minimum required version of **XMP** (when used) is bumped to **4.5** (was 4.2). There were two different implementations of the file handling here, depending on version. I only rewrote the newer one and removed the old altogether.

Structures in the PAK handling and parts of the removed file handling used **Z_Malloc**. I didn't see a reason for any of this to waste space in the **zone memory** so now it all just uses malloc.

I also made some other small adjustments to adjacent code that didn't seem quite right, such as the id3 tag code reading values from buffers without checking the results from file reads now getting a memset to 0 of the buffer between reads.

@andrei-drexler This is your project, so if you want me to change anything about this, big or small, just let me know and I'll take care of it.

@NightFright2k19 You posted the original feature request, feel free to try it out and post feedback.