### PR TITLE
Sound Filter options (sndspeed but more UX friendly)

### DIFF
--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -66,6 +66,7 @@ extern cvar_t r_md5;
 extern cvar_t r_lerpmodels;
 extern cvar_t r_lerpmove;
 extern cvar_t snd_waterfx;
+extern cvar_t snd_filter;
 extern cvar_t joy_deadzone_look;
 extern cvar_t joy_deadzone_move;
 extern cvar_t joy_deadzone_trigger;
@@ -3239,6 +3240,7 @@ void M_Menu_Gamepad_f (void)
 		item (SPACER,					"")								\
 		item (OPT_MUSICEXT,				"External Music")				\
 		item (OPT_WATERSNDFX,			"Water Muffling")				\
+		item (OPT_SNDFILTER,			"Sound Filter")					\
 	end_menu ()															\
 ////////////////////////////////////////////////////////////////////////
 
@@ -3706,6 +3708,9 @@ void M_AdjustSliders (int dir)
 		break;
 	case OPT_WATERSNDFX:
 		Cbuf_AddText ("toggle snd_waterfx\n");
+		break;
+	case OPT_SNDFILTER:
+		Cbuf_AddText ("toggle snd_filter\n");
 		break;
 
 	case OPT_HUDSTYLE:	// hud style
@@ -4352,6 +4357,10 @@ static void M_Options_DrawItem (int y, int item)
 
 	case OPT_WATERSNDFX:
 		M_DrawCheckbox (x, y, snd_waterfx.value);
+		break;
+
+	case OPT_SNDFILTER:
+		M_DrawCheckbox (x, y, snd_filter.value);
 		break;
 
 	case OPT_ALWAYSRUN:

--- a/Quake/q_sound.h
+++ b/Quake/q_sound.h
@@ -170,7 +170,7 @@ extern	vec3_t		listener_forward;
 extern	vec3_t		listener_right;
 extern	vec3_t		listener_up;
 
-extern	cvar_t		sndspeed;
+extern	cvar_t		snd_filter;
 extern	cvar_t		snd_mixspeed;
 extern	cvar_t		snd_filterquality;
 extern	cvar_t		sfxvolume;

--- a/Quake/snd_dma.c
+++ b/Quake/snd_dma.c
@@ -78,7 +78,7 @@ cvar_t		sfxvolume = {"volume", "0.7", CVAR_ARCHIVE};
 cvar_t		precache = {"precache", "1", CVAR_NONE};
 cvar_t		loadas8bit = {"loadas8bit", "0", CVAR_NONE};
 
-cvar_t		sndspeed = {"sndspeed", "11025", CVAR_NONE};
+cvar_t		snd_filter = {"snd_filter", "0", CVAR_ARCHIVE};
 cvar_t		snd_mixspeed = {"snd_mixspeed", "44100", CVAR_NONE};
 
 cvar_t		snd_waterfx = {"snd_waterfx", "1", CVAR_ARCHIVE};
@@ -174,7 +174,7 @@ void S_Init (void)
 	Cvar_RegisterVariable(&snd_noextraupdate);
 	Cvar_RegisterVariable(&snd_show);
 	Cvar_RegisterVariable(&_snd_mixahead);
-	Cvar_RegisterVariable(&sndspeed);
+	Cvar_RegisterVariable(&snd_filter);
 	Cvar_RegisterVariable(&snd_mixspeed);
 	Cvar_RegisterVariable(&snd_filterquality);
 	Cvar_RegisterVariable(&snd_waterfx);
@@ -190,10 +190,10 @@ void S_Init (void)
 	Cmd_AddCommand("soundlist", S_SoundList);
 	Cmd_AddCommand("soundinfo", S_SoundInfo_f);
 
-	i = COM_CheckParm("-sndspeed");
+	i = COM_CheckParm("-snd_filter");
 	if (i && i < com_argc-1)
 	{
-		Cvar_SetQuick (&sndspeed, com_argv[i + 1]);
+		Cvar_SetQuick (&snd_filter, com_argv[i + 1]);
 	}
 
 	i = COM_CheckParm("-mixspeed");

--- a/Quake/snd_mix.c
+++ b/Quake/snd_mix.c
@@ -505,7 +505,7 @@ void S_PaintChannels (int endtime)
 		}
 
 	// apply a lowpass filter
-		if (sndspeed.value == 11025 && shm->speed == 44100)
+		if (snd_filter.value == 1)
 		{
 			static filter_t memory_l, memory_r;
 			S_LowpassFilter((int *)paintbuffer,       2, end - paintedtime, &memory_l);


### PR DESCRIPTION
Adds a "Sound filter" option under "game" section in options. It switches on-off the low-pass filter which is applied when the game is resampling a 11.125 kHz audio to 44.1 kHz (so it rids off the "crunch-ness" effect that creates the resampling.


![imagen](https://github.com/user-attachments/assets/2d5e9de9-25b0-46b7-8e03-c07cded767e8)

This is a continuation of #314 which was mistakenly closed because I made a force pull request. In that thread we discuss how to solve this problem.

Also this changes the `sndspeed` option to be `snd_filter` for some reasons:
1. There's already a `snd_filterquality` variable, that does exactly what it says, so it fits well with `snd_filter`
2. sndspeed was either way a switch between 11125 and other values. It's pointless to have an exact numerical value and leaves confussion. A boolean option should be more intuitive.
3. Bad naming in my viewpoint. What is sound "speed"?
4. Theres already `snd_mixspeed` that actually does change the sample rate in more intervals.

`snd_filter` is now a boolean value instead of a boolean value hidden under an int value. Also this cvar is persistent in the user options (unlike `sndspeed`)

Still I should change the on/off switch to a more suitable "classic vs remastered" or "retro vs off" to give more hints to the user (like how it's done in the models option under the graphics section). When I do change it I will mark this PR as ready.

I'm not an expert or a professional, any feedback will be appreciated. It's a small change but pretty necesary (#169)