### PR TITLE
Hide speedometer at intermissions/cutscenes

### DIFF
--- a/Quake/gl_screen.c
+++ b/Quake/gl_screen.c
@@ -752,6 +752,9 @@ SCR_DrawSpeed
 */
 void SCR_DrawSpeed (void)
 {
+    if (cl.intermission || CL_InCutscene () || scr_viewsize.value >= 130)
+		return;
+
 	const float show_speed_interval_value = 0.05f;
 	static float maxspeed = 0, display_speed = -1;
 	static double lastrealtime = 0;


### PR DESCRIPTION
Speedometer would show even on Photo mode and cutscenes, having to manually disable it to take a clean screenshot.

![e1m3_2024-11-06_10-56-26](https://github.com/user-attachments/assets/b343b180-c285-44e6-a29d-c327e9ae5d87)

This pull request should fix that, let me know if there are any issues with it. Thanks!