### PR TITLE
Rich Presence: Show mapname if levelname is empty

### DIFF
--- a/Quake/host.c
+++ b/Quake/host.c
@@ -1078,9 +1078,9 @@ static void UpdateWindowTitle (void)
 		VID_SetWindowTitle (title);
 
 		if (current.stats.max_players > 1)
-			Steam_SetStatus_Multiplayer (current.stats.players, current.stats.max_players, utf8name);
+			Steam_SetStatus_Multiplayer (current.stats.players, current.stats.max_players, utf8name[0] ? utf8name : current.map);
 		else
-			Steam_SetStatus_SinglePlayer (utf8name);
+			Steam_SetStatus_SinglePlayer (utf8name[0] ? utf8name : current.map);
 	}
 	else
 	{


### PR DESCRIPTION
Before:
![crop](https://github.com/user-attachments/assets/4a18480d-093a-42ca-a79d-411876108250)
After:
![crop2](https://github.com/user-attachments/assets/4ba16326-bd77-4056-8541-608c707caa1f)
