### PR TITLE
Added legacy (GE/PD) style gamepad controls.

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -879,21 +879,59 @@ static void IN_JoyKeyEvent(qboolean wasdown, qboolean isdown, int key, double *t
 	}
 }
 
-static joyaxis_t IN_GetLookAxis (joyaxisstate_t *state)
-{
+// Add a new control scheme option
+#define JOY_SCHEME_DEFAULT 0
+#define JOY_SCHEME_SWAP 1
+#define JOY_SCHEME_LEGACY 2
+
+static joyaxis_t IN_GetLookAxis(joyaxisstate_t *state) {
 	joyaxis_t axis;
-	axis.x = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTX : SDL_CONTROLLER_AXIS_RIGHTX];
-	axis.y = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTY : SDL_CONTROLLER_AXIS_RIGHTY];
+
+	switch ((int)joy_swapmovelook.value) {
+		case JOY_SCHEME_LEGACY:
+			// GoldenEye 1.1 setup: rotate and move forward/backward on the left stick, strafe and up/down look on the right stick
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTY];
+		break;
+		case JOY_SCHEME_SWAP:
+			// Swapped move/look configuration
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTY];
+		break;
+		default: // JOY_SCHEME_DEFAULT
+			// Default configuration
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTY];
+		break;
+	}
+
 	return axis;
 }
 
-static joyaxis_t IN_GetMoveAxis (joyaxisstate_t *state)
-{
+static joyaxis_t IN_GetMoveAxis(joyaxisstate_t *state) {
 	joyaxis_t axis;
-	axis.x = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTX : SDL_CONTROLLER_AXIS_LEFTX];
-	axis.y = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTY : SDL_CONTROLLER_AXIS_LEFTY];
+
+	switch ((int)joy_swapmovelook.value) {
+		case JOY_SCHEME_LEGACY:
+			// GoldenEye 1.1 setup: rotate and move forward/backward on the left stick, strafe and up/down look on the right stick
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTY];
+		break;
+		case JOY_SCHEME_SWAP:
+			// Swapped move/look configuration
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_RIGHTY];
+		break;
+		default: // JOY_SCHEME_DEFAULT
+			// Default configuration
+			axis.x = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTX];
+			axis.y = state->axisvalue[SDL_CONTROLLER_AXIS_LEFTY];
+		break;
+	}
+
 	return axis;
 }
+
 
 static qboolean IN_JoyActive (void)
 {
@@ -1496,7 +1534,7 @@ float IN_GetRawLookMagnitude (void)
 	if (!joy_active_controller)
 		return 0.f;
 
-	axis.x = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTX : SDL_CONTROLLER_AXIS_RIGHTX];
+	axis.x = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTX : SDL_CONTROLLER_AXIS_RIGHTX ];
 	axis.y = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTY : SDL_CONTROLLER_AXIS_RIGHTY];
 
 	return IN_AxisMagnitude (axis);

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -3927,7 +3927,7 @@ void M_AdjustSliders (int dir)
 		Cvar_SetValueQuick (&joy_invert, !joy_invert.value);
 		break;
 	case GPAD_OPT_SWAP_MOVELOOK:
-		Cvar_SetValueQuick (&joy_swapmovelook, !joy_swapmovelook.value);
+		Cvar_SetValueQuick(&joy_swapmovelook, fmod(joy_swapmovelook.value + 1, 3));
 		break;
 	case GPAD_OPT_EXPONENT_LOOK:
 		Cvar_SetValueQuick (&joy_exponent, CLAMP (MIN_JOY_EXPONENT, joy_exponent.value + dir * 0.5f, MAX_JOY_EXPONENT));
@@ -4549,7 +4549,20 @@ static void M_Options_DrawItem (int y, int item)
 		M_DrawCheckbox (x, y, joy_invert.value);
 		break;
 	case GPAD_OPT_SWAP_MOVELOOK:
-		M_Print (x, y, joy_swapmovelook.value ? "Left" : "Right");
+		switch ((int)joy_swapmovelook.value) {
+			case 0:
+				M_Print(x, y, "Right");
+				break;
+			case 1:
+				M_Print(x, y, "Left");
+				break;
+			case 2:
+				M_Print(x, y, "Legacy");
+				break;
+			default:
+				M_Print(x, y, "Unknown");
+				break;
+			}
 		break;
 	case GPAD_OPT_EXPONENT_LOOK:
 		r = (joy_exponent.value - MIN_JOY_EXPONENT) / (MAX_JOY_EXPONENT - MIN_JOY_EXPONENT);

--- a/Quakespasm.html
+++ b/Quakespasm.html
@@ -141,7 +141,9 @@ where DRIVER may be alsa, dsp, pulse, esd ...</LI>
 <LI>joy_exponent - For the look stick, the stick displacement (between 0 and 1) is raised to this power. Default is 2. A value of 1 would give a linear relationship between stick displacement and fraction of the maximum angular speed.</LI>
 <LI>joy_exponent_move - Same as joy_exponent but for the move stick. Default is 2.</LI>
 <LI>joy_invert - Set to 1 to invert the vertical axis of the look stick.</LI>
-<LI>joy_swapmovelook - Set to 1 to swap the left and right analog stick functions. Default is 0, move on the left stick, look on the right stick.</LI>
+<LI>joy_swapmovelook - Set to 2 for legacy (GE/PD 1.1) style controls (move forward/backward look left/right on left stick, move left/right and look up/down on right stick.
+ Set to 1 to swap the left and right analog stick functions.
+ Default is 0, move on the left stick, look on the right stick.</LI>
 <LI>joy_enable - Set to 0 to disable controller support. Default is 1.</LI>
 </UL>
 </P>

--- a/Quakespasm.txt
+++ b/Quakespasm.txt
@@ -3,7 +3,7 @@
   ______________________________________________________________________
 
 
-  Page last edited: July 2024.
+  Page last edited: January 2025.
 
 
   1. About
@@ -129,9 +129,9 @@
   -  joy_invert - Set to 1 to invert the vertical axis of the look
      stick.
 
-  -  joy_swapmovelook - Set to 1 to swap the left and right analog stick
-     functions. Default is 0, move on the left stick, look on the right
-     stick.
+  -  joy_swapmovelook - Set to 2 for legacy (GE/PD 1.1) style controls (move forward/backward look left/right on left stick, move left/right and look up/down on right stick.
+  Set to 1 to swap the left and right analog stick functions.
+  Default is 0, move on the left stick, look on the right stick.
 
   -  joy_enable - Set to 0 to disable controller support. Default is 1.
 


### PR DESCRIPTION
I added the option to have GE/PD 1.1 style gamepad controls (forward/backward turn left/right on the left stick, strafe left/right and look up/down on the right stick) as i grew up on that control scheme and am still used to it.

This is the first time i added anything to an open source project and i would love to receive feedback about my code as i feel while it adds the desired functionality it might not be in line with the style of the project. 

Fun sidenote: this was all thought of and actually programmed after a NYE party at 7 AM in the morning.

Cheers