### PR TITLE
Route extra texture types to developer > 1

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1960,6 +1960,7 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 			strcmp(ext, "tga") != 0 &&
 			strcmp(ext, "png") != 0 &&
 			strcmp(ext, "jpg") != 0 &&
+			strcmp(ext, "lmp") != 0 &&
 			strcmp(ext, "lit") != 0 &&
 			strcmp(ext, "vis") != 0 &&
 			strcmp(ext, "ent") != 0)

--- a/Quake/common.c
+++ b/Quake/common.c
@@ -1958,6 +1958,8 @@ static int COM_FindFile (const char *filename, int *handle, FILE **file,
 
 		if (strcmp(ext, "pcx") != 0 &&
 			strcmp(ext, "tga") != 0 &&
+			strcmp(ext, "png") != 0 &&
+			strcmp(ext, "jpg") != 0 &&
 			strcmp(ext, "lit") != 0 &&
 			strcmp(ext, "vis") != 0 &&
 			strcmp(ext, "ent") != 0)


### PR DESCRIPTION
Quakespasm does not show FindFile errors for external textures, but because Ironwail supports more file types, jpg, png, and lmp do not get ignored. This makes all of the file types be treated the same.

This could be expanded to music types and `.md5mesh`, but I just went for the external texture types for now.