### PR TITLE
Fix base dir in current directory

### DIFF
--- a/Quake/common.c
+++ b/Quake/common.c
@@ -3037,6 +3037,8 @@ static void COM_InitBaseDir (void)
 		goto try_egs;
 
 	// try current working directory, then its ancestors (in case the executable is in its own subdirectory)
+	if (COM_SetBaseDir (host_parms->basedir))
+		return;
 	if (COM_SetBaseDirRec (host_parms->basedir))
 		return;
 


### PR DESCRIPTION
In changeset cede6814fcefde93dc3946354ce07a8fb1acfd02 the determining of basedir was slightly altered, it no longer attempts to use the current working directory. I believe it was by mistake as the comment suggests it still should.

The problem comes from COM_SetBaseDirRec only testing ancestors and not the directory itself. Re-adding COM_SetBaseDir before it fixes the problem.