### PR TITLE
HIDAPI SDL_Hints and fixed PlayStation Rumble & Gyro functionality under Bluetooth mode

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -464,29 +464,59 @@ static qboolean IN_RemapJoystick (void)
 
 void IN_StartupJoystick (void)
 {
-	int i;
-	int nummappings;
-	char controllerdb[MAX_OSPATH];
-	
-	if (COM_CheckParm("-nojoy"))
-		return;
+    int i;
+    int nummappings;
+    char controllerdb[MAX_OSPATH];
 
-	if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1 )
-	{
-		Con_Warning("could not initialize SDL Game Controller\n");
-		return;
-	}
+    if (COM_CheckParm("-nojoy"))
+        return;
 
-	// Load additional SDL2 controller definitions from gamecontrollerdb.txt
-	for (i = 0; i < com_numbasedirs; i++)
-	{
-		q_snprintf (controllerdb, sizeof(controllerdb), "%s/gamecontrollerdb.txt", com_basedirs[i]);
-		nummappings = SDL_GameControllerAddMappingsFromFile(controllerdb);
-		if (nummappings > 0)
-			Con_Printf("%d mappings loaded from gamecontrollerdb.txt\n", nummappings);
-	}
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS5, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_SWITCH, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
 
-	IN_SetupJoystick ();
+	// Enable rumble and motion sensors for PS4 and PS5 controllers while uder Bluetooth connectivitiy
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 23, 2)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_COMBINE_JOY_CONS, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 25, 1)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS3, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 26, 0)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+	SDL_SetHint (SDL_HINT_JOYSTICK_RAWINPUT, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_RAWINPUT_CORRELATE_XINPUT, "1");
+#endif
+
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1)
+    {
+        Con_Warning("could not initialize SDL Game Controller\n");
+        return;
+    }
+
+    // Load additional SDL2 controller definitions from gamecontrollerdb.txt
+    for (i = 0; i < com_numbasedirs; i++)
+    {
+        q_snprintf(controllerdb, sizeof(controllerdb), "%s/gamecontrollerdb.txt", com_basedirs[i]);
+        nummappings = SDL_GameControllerAddMappingsFromFile(controllerdb);
+        if (nummappings > 0)
+            Con_Printf("%d mappings loaded from gamecontrollerdb.txt\n", nummappings);
+    }
+
+    IN_SetupJoystick();
 }
 
 void IN_ShutdownJoystick (void)


### PR DESCRIPTION
For context: https://github.com/libsdl-org/SDL/issues/10086 

This is a known issue with SDL2's HIDAPI where PS4/PS5_Rumble will be disabled by default. It won't be using the Enhanced feature mode for PlayStation Controllers under Bluetooth mode...but what it doesn't tell you that it also disables Motion Sensor functionality. if you wanna play Ironwail and try out the Gyro features...but you don't have cables around: Bluetooth is your only option....which does not work.

This has been addressed in SDL3 by replacing both of them with `SDL_HINT_JOYSTICK_ENHANCED_REPORTS` https://github.com/sezero/SDL/commit/2c0a8363a5073bfb23ddb18d7c75f43e624db570, and enabled by default. However: Ironwail is using SDL2....

if you don't have both `SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE` and `SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE` hints: Rumble and Gyro Aiming will not work when under Bluetooth. This commit fixes that problem while introducing various hints for enhancing Controller-specific feature sets (one of them is improved Xbox Controller support via RawInput).