### PR TITLE
Gyro Space support / 3DOF to 2D Conversion Style for "gyro_turning_axis"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "Quake/GyroSpace"]
+	path = Quake/GyroSpace
+	url = https://github.com/AL2009man/GyroSpace-and-Play.git
+	branch = 0.4.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ if (WIN32)
 	list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Windows/cmake-modules)
 endif()
 
+# Gyro Space and Play header for additional gyro_turning_axis modes
+include_directories(${CMAKE_SOURCE_DIR}/GyroSpace-and-Play)
+
 find_package(SDL2 REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(CURL)

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -1709,14 +1709,47 @@ void IN_SendKeyEvents (void)
 
 				// Gyro Axis Selection
 				switch ((int)gyro_turning_axis.value) {
-				case 0: // Yaw Mode
+				case 0: // Yaw
 					gyro_yaw = event.csensor.data[1] - gyro_calibration_y.value;
 					break;
-				case 1: // Roll Mode
+				case 1: // Roll
 					gyro_yaw = -(event.csensor.data[2] - gyro_calibration_z.value);
 					break;
+				case 2: // Local Space
+				{
+					Vector3 localGyro = TransformToLocalSpace (
+						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
+						1.0f, 1.0f, 1.0f, 0.5f // Uses default sensitivity values for now
+					);
+					gyro_yaw = localGyro.x;
+					gyro_pitch = localGyro.y;
+				}
+				break;
+				case 3: // Player Space
+				{
+					Vector3 playerGyro = TransformToPlayerSpace (
+						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
+						GetGravityVector (), // Gravity-aligned transformation
+						1.0f, 1.0f, 1.0f
+					);
+					gyro_yaw = playerGyro.x;
+					gyro_pitch = playerGyro.y;
+				}
+				break;
+				case 4: // World Space
+				{
+					Vector3 worldGyro = TransformToWorldSpace (
+						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
+						GetGravityVector (), // Gravity-aligned transformation
+						1.0f, 1.0f, 1.0f
+					);
+					gyro_yaw = worldGyro.x;
+					gyro_pitch = worldGyro.y;
+				}
+				break;
 				default:
-					gyro_yaw = 0.f; // Future axis modes can be added here
+					gyro_yaw = 0.f;
+					gyro_pitch = 0.f;
 					break;
 				}
 

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -31,6 +31,8 @@ https://github.com/yquake2/yquake2/blob/master/src/client/input/sdl.c
 #include "SDL.h"
 #endif
 
+#include "GyroSpace/GyroSpace.h"
+
 extern cvar_t ui_mouse;
 extern cvar_t language;
 

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -31,7 +31,7 @@ https://github.com/yquake2/yquake2/blob/master/src/client/input/sdl.c
 #include "SDL.h"
 #endif
 
-#include "GyroSpace/GyroSpace.h"
+#include "../../GyroSpace-and-Play/GyroSpace.h"
 
 extern cvar_t ui_mouse;
 extern cvar_t language;
@@ -1721,7 +1721,7 @@ void IN_SendKeyEvents (void)
 				{
 					Vector3 localGyro = TransformToLocalSpace (
 						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
-						1.0f, 1.0f, 1.0f, 0.5f // Uses default sensitivity values for now
+						1.0f, 1.0f, 1.0f, 0.5f 
 					);
 					gyro_yaw = localGyro.x;
 					gyro_pitch = localGyro.y;
@@ -1731,7 +1731,7 @@ void IN_SendKeyEvents (void)
 				{
 					Vector3 playerGyro = TransformToPlayerSpace (
 						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
-						GetGravityVector (), // Gravity-aligned transformation
+						GetGravityVector (),
 						1.0f, 1.0f, 1.0f
 					);
 					gyro_yaw = playerGyro.x;
@@ -1742,7 +1742,7 @@ void IN_SendKeyEvents (void)
 				{
 					Vector3 worldGyro = TransformToWorldSpace (
 						event.csensor.data[1], event.csensor.data[0], event.csensor.data[2],
-						GetGravityVector (), // Gravity-aligned transformation
+						GetGravityVector (), 
 						1.0f, 1.0f, 1.0f
 					);
 					gyro_yaw = worldGyro.x;

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -1707,15 +1707,25 @@ void IN_SendKeyEvents (void)
 				if (IN_UpdateGyroCalibration (event.csensor.data))
 					break;
 
-				if (!gyro_turning_axis.value)
-					gyro_yaw = event.csensor.data[1] - gyro_calibration_y.value; // yaw
-				else
-					gyro_yaw = -(event.csensor.data[2] - gyro_calibration_z.value); // roll
+				// Gyro Axis Selection
+				switch ((int)gyro_turning_axis.value) {
+				case 0: // Yaw Mode
+					gyro_yaw = event.csensor.data[1] - gyro_calibration_y.value;
+					break;
+				case 1: // Roll Mode
+					gyro_yaw = -(event.csensor.data[2] - gyro_calibration_z.value);
+					break;
+				default:
+					gyro_yaw = 0.f; // Future axis modes can be added here
+					break;
+				}
+
 				gyro_pitch = event.csensor.data[0] - gyro_calibration_x.value;
 
-				// Save unfiltered magnitude to display in the UI
-				gyro_raw_mag = RAD2DEG (sqrt (gyro_yaw*gyro_yaw + gyro_pitch*gyro_pitch));
+				// Save unfiltered magnitude for UI display
+				gyro_raw_mag = RAD2DEG (sqrt (gyro_yaw * gyro_yaw + gyro_pitch * gyro_pitch));
 
+				// Apply filtering to smooth gyro movements
 				gyro_yaw = IN_FilterGyroSample (prev_yaw, gyro_yaw);
 				gyro_pitch = IN_FilterGyroSample (prev_pitch, gyro_pitch);
 			}

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -4600,7 +4600,26 @@ static void M_Options_DrawItem (int y, int item)
 		}
 		break;
 	case GPAD_OPT_GYROAXIS:
-		M_Print(x, y, gyro_turning_axis.value ? "roll (lean)" : "yaw (turn)");
+		switch ((int)gyro_turning_axis.value) {
+		case 0:
+			M_Print (x, y, "yaw (turn)");
+			break;
+		case 1:
+			M_Print (x, y, "roll (lean)");
+			break;
+		case 2:
+			M_Print (x, y, "local space");
+			break;
+		case 3:
+			M_Print (x, y, "player space");
+			break;
+		case 4:
+			M_Print (x, y, "world space");
+			break;
+		default:
+			M_Print (x, y, "unknown gyro axis");
+			break;
+		}
 		break;
 	case GPAD_OPT_GYROSENSX:
 		r = (gyro_yawsensitivity.value - MIN_GYRO_SENS) / (MAX_GYRO_SENS - MIN_GYRO_SENS);

--- a/Quake/menu.c
+++ b/Quake/menu.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (C) 1996-2001 Id Software, Inc.
 Copyright (C) 2002-2009 John Fitzgibbons and others
 Copyright (C) 2010-2014 QuakeSpasm developers
@@ -3957,7 +3957,7 @@ void M_AdjustSliders (int dir)
 		Cvar_SetValueQuick (&gyro_mode, (int)(q_max (gyro_mode.value, 0.f) + GYRO_MODE_COUNT + dir) % GYRO_MODE_COUNT);
 		break;
 	case GPAD_OPT_GYROAXIS:
-		Cvar_SetValueQuick (&gyro_turning_axis, !gyro_turning_axis.value);
+		Cvar_SetValueQuick (&gyro_turning_axis, (int)(q_max (gyro_turning_axis.value, 0.f) + 5 + dir) % 5);
 		break;
 	case GPAD_OPT_GYROSENSX:
 		Cvar_SetValueQuick (&gyro_yawsensitivity, CLAMP (MIN_GYRO_SENS, gyro_yawsensitivity.value + dir * .1f, MAX_GYRO_SENS));
@@ -4601,24 +4601,11 @@ static void M_Options_DrawItem (int y, int item)
 		break;
 	case GPAD_OPT_GYROAXIS:
 		switch ((int)gyro_turning_axis.value) {
-		case 0:
-			M_Print (x, y, "yaw (turn)");
-			break;
-		case 1:
-			M_Print (x, y, "roll (lean)");
-			break;
-		case 2:
-			M_Print (x, y, "local space");
-			break;
-		case 3:
-			M_Print (x, y, "player space");
-			break;
-		case 4:
-			M_Print (x, y, "world space");
-			break;
-		default:
-			M_Print (x, y, "unknown gyro axis");
-			break;
+		case 0: M_Print (x, y, "yaw (turn)"); break;
+		case 1: M_Print (x, y, "roll (lean)"); break;
+		case 2: M_Print (x, y, "local space"); break;
+		case 3: M_Print (x, y, "player space"); break;
+		case 4: M_Print (x, y, "world space"); break;
 		}
 		break;
 	case GPAD_OPT_GYROSENSX:


### PR DESCRIPTION
coming from https://github.com/yquake2/yquake2/pull/1194, I decided to give Quake 1 the same treatment! That means: I get to shamelessly copy-paste from the sister PR!


https://github.com/user-attachments/assets/37e251cd-fbd6-4f8d-8f14-89484d593222

For those who don't know, and I will try to summarize it. Gyro Space is meant to address an issue with how a Player holds a controller or a device, this offer will provide three modes:

- Local Space: combined both the existing "Yaw (Turn)" and "Roll (Pitch)" axis into one, with minor transition changes. No need to choose between Yaw and Roll anymore, while being more handheld-friendly.
- Player Space: will try to account for how a Quake 1 player holds a Controller while resisting the errors of World Space.
- World Space: formerly known as Sensor Fusion in "marketing" terms, tries to ensure the gravity of the controller. 
   - **This is something you'll find in most games developed by Nintendo.**

for more detail, [refer to GyroWiki website that talks about to Player Space Gyro](http://gyrowiki.jibbsmart.com/blog:player-space-gyro-and-alternatives-explained). If it weren't for @JibbSmart: This would never be a thing. That's why a significant portion of the code were derived from ([including GamepadMotionHelpers](https://github.com/JibbSmart/GamepadMotionHelpers))

[This codeset is powered by my GyroSpace.h header](https://github.com/AL2009man/GyroSpace-and-Play), a work-in-progress build of a plug-and-play implementation of Gyro Space. Thus: this will become a submodule for easier maintenance.

However, there are still things that need to be addressed before an official PR Merge can occur:

- [ ] World Space needs to function similarly to Steam Input's Gyro Orientation version or, has a 17.4% displacement error when trying to tilt 10 degrees
- [ ] test on Controller Types and Connectivity Types. **This includes handheld devices. Local Space will need to be tested!**