### PR TITLE
Enable DO_USERDIRS by default for Unix-like platforms

### DIFF
--- a/Quake/Makefile
+++ b/Quake/Makefile
@@ -5,7 +5,7 @@
 # "make DO_USERDIRS=1" to enable user directories support
 
 # Enable/Disable user directories support
-DO_USERDIRS=0
+DO_USERDIRS=1
 
 ### Enable/Disable SDL2
 USE_SDL2=1


### PR DESCRIPTION
This is a small change to enable user directories by default, on build, for platforms that typically have their binaries stored separately from data files.  The intent is to have `make` behave like `make DO_USERDIRS=1` does in the present state, so that the expected behavior for Unix-like platforms is the obvious choice for e.g. package maintainers for distributions who want to maintain consistent behavior with other distributions.

Note: this is a somewhat *opinionated* change (behavior with `DO_USERDIRS=0` is to search the user's steam directory first, which in my case is undesirable).  The creation of this pull request is not meant to imply that the changes are the best solution for everyone, rather it is a suggestion.