### PR TITLE
Add manual build workflow

### DIFF
--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -1,5 +1,15 @@
 name: Windows CI
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      isRelease:
+        description: "Release Build?"
+        required: true
+        default: true
+        type: boolean
+    
 jobs:
   build:
     name: Windows / ${{ matrix.platform }}
@@ -15,6 +25,7 @@ jobs:
         $gitrev = $(git describe --always)
         $gitbranch = $(git branch --show-current)
         $ver_suffix = ("$gitbranch" -eq "master" -Or "$gitbranch" -eq "main") ? "-$gitrev" : "-$gitbranch-$gitrev"
+        $ver_suffix = "${{((github.event_name != 'workflow_dispatch' || !inputs.isRelease) && '$ver_suffix') || ''}}"
         $platform_alt = ("${{matrix.platform}}" -eq "x64") ? "win64" : "win32"
         $platform_short = ("${{matrix.platform}}" -eq "Win32") ? "x86" : "${{matrix.platform}}"
         $build_artifact = "ironwail${ver_suffix}-${platform_alt}"


### PR DESCRIPTION
Adds a manual dispatch option to the Windows CI workflow.  Leaving the "Release Build?" option checked omits the commit hash from environment variables.

### Notes

Have tested building (works as expected) but haven't checked the binaries

Leaving as a draft b/c I'm not sure this accomplishes what I set out to do, I just inferred that the environment variables are used to set version number inside the program