### PR TITLE
Added option to fix sliding from gravity and bouncing on ramps

### DIFF
--- a/Quake/quakedef.h
+++ b/Quake/quakedef.h
@@ -113,6 +113,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	MAX_STYLESTRING		64
 
+// [B] How the map should handle ramps.
+typedef enum
+{
+	RAMP_USER		= -1, // Let the cvar decide.
+	RAMP_VANILLA	= 0,
+	RAMP_MODERN		= 1,
+} rampfix_t;
+
 //
 // stats are integers communicated to the client by the server
 //


### PR DESCRIPTION
These have been issues that have long plagued mappers and casual players alike, with the grenade bouncing down ramps being particularly egregious. I've decided to lump both of these issues under one fix, `sv_fixrampphysics`, because I highly doubt someone would want to fix one but not the other. I consider this largely unobtrusive as the code is pretty simple to maintain and it doesn't drastically impact the validity of other ports.

Without fix (vanilla):
https://github.com/user-attachments/assets/d87ca284-867e-4bb6-8dd5-e87ab73ca213

With fix:
https://github.com/user-attachments/assets/491473b4-b334-4d3d-a7bf-2fafa9365dfa

I'd like to add an option for the map itself to dictate this, however, that feature is currently untested as is the full scope of how this impacts velocity clipping. I'm willing to put all the work needed into fixing it up and getting the ball rolling, but I'm mostly presenting this PR to ask a question: is Ironwail interested in changes like this? I've noticed some people have been eyeing Ironwail for gamedev recently, and while this naturally doesn't have to dictate anything about its direction, I do think it'd be nice to give people an option to easily flip the switch in their own forks to avoid having to deal with these problems at the very least. They can get pretty obnoxious in the wrong circumstances and it limits map design in frankly annoying, unintuitive ways. Since it's such a simple fix compared to something more complex like rotating BSPs, I wanted to at least present the idea.