### PR TITLE
Allow guide button remap

### DIFF
--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -1,0 +1,1753 @@
+/*
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2002-2005 John Fitzgibbons and others
+Copyright (C) 2007-2008 Kristian Duske
+Copyright (C) 2010-2014 QuakeSpasm developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+gyro related code is based on
+https://github.com/yquake2/yquake2/blob/master/src/client/input/sdl.c
+
+*/
+
+#include "quakedef.h"
+#if defined(SDL_FRAMEWORK) || defined(NO_SDL_CONFIG)
+#include <SDL2/SDL.h>
+#else
+#include "SDL.h"
+#endif
+
+extern cvar_t ui_mouse;
+extern cvar_t language;
+
+static qboolean windowhasfocus = true;	//just in case sdl fails to tell us...
+static textmode_t textmode = TEXTMODE_OFF;
+static keydevice_t lastactivetype = KD_NONE;
+
+static cvar_t in_debugkeys = {"in_debugkeys", "0", CVAR_NONE};
+
+#ifdef __APPLE__
+/* Mouse acceleration needs to be disabled on OS X */
+#define MACOS_X_ACCELERATION_HACK
+#endif
+
+#ifdef MACOS_X_ACCELERATION_HACK
+#include <IOKit/IOTypes.h>
+#include <IOKit/hidsystem/IOHIDLib.h>
+#include <IOKit/hidsystem/IOHIDParameter.h>
+#include <IOKit/hidsystem/event_status_driver.h>
+#endif
+
+// SDL2 Game Controller cvars
+cvar_t	joy_deadzone_look = { "joy_deadzone_look", "0.175", CVAR_ARCHIVE };
+cvar_t	joy_deadzone_move = { "joy_deadzone_move", "0.175", CVAR_ARCHIVE };
+cvar_t	joy_outer_threshold_look = { "joy_outer_threshold_look", "0.02", CVAR_ARCHIVE };
+cvar_t	joy_outer_threshold_move = { "joy_outer_threshold_move", "0.02", CVAR_ARCHIVE };
+cvar_t	joy_deadzone_trigger = { "joy_deadzone_trigger", "0.2", CVAR_ARCHIVE };
+cvar_t	joy_sensitivity_yaw = { "joy_sensitivity_yaw", "240", CVAR_ARCHIVE };
+cvar_t	joy_sensitivity_pitch = { "joy_sensitivity_pitch", "130", CVAR_ARCHIVE };
+cvar_t	joy_invert = { "joy_invert", "0", CVAR_ARCHIVE };
+cvar_t	joy_exponent = { "joy_exponent", "2", CVAR_ARCHIVE };
+cvar_t	joy_exponent_move = { "joy_exponent_move", "2", CVAR_ARCHIVE };
+cvar_t	joy_swapmovelook = { "joy_swapmovelook", "0", CVAR_ARCHIVE };
+cvar_t	joy_flick = { "joy_flick", "0", CVAR_ARCHIVE };
+cvar_t	joy_flick_time = { "joy_flick_time", "0.125", CVAR_ARCHIVE };
+cvar_t	joy_flick_recenter = { "joy_flick_recenter", "0.0", CVAR_ARCHIVE };
+cvar_t	joy_flick_deadzone = { "joy_flick_deadzone", "0.9", CVAR_ARCHIVE };
+cvar_t	joy_flick_noise_thresh = { "joy_flick_noise_thresh", "2.0", CVAR_ARCHIVE };
+cvar_t	joy_flick_adjust_speed = { "joy_flick_adjust_speed", "30.0", CVAR_ARCHIVE };
+cvar_t	joy_rumble = { "joy_rumble", "0.3", CVAR_ARCHIVE };
+cvar_t	joy_device = { "joy_device", "0", CVAR_ARCHIVE };
+cvar_t	joy_always_active = { "joy_always_active", "0", CVAR_ARCHIVE };
+
+cvar_t gyro_enable = {"gyro_enable", "1", CVAR_ARCHIVE};
+cvar_t gyro_mode = {"gyro_mode", "2", CVAR_ARCHIVE}; // 2 = GYRO_BUTTON_DISABLES (see gyromode_t)
+cvar_t gyro_turning_axis = {"gyro_turning_axis", "0", CVAR_ARCHIVE};
+
+cvar_t gyro_yawsensitivity = {"gyro_yawsensitivity", "2.5", CVAR_ARCHIVE};
+cvar_t gyro_pitchsensitivity= {"gyro_pitchsensitivity", "2.5", CVAR_ARCHIVE};
+
+cvar_t gyro_calibration_x = {"gyro_calibration_x", "0", CVAR_ARCHIVE};
+cvar_t gyro_calibration_y = {"gyro_calibration_y", "0", CVAR_ARCHIVE};
+cvar_t gyro_calibration_z = {"gyro_calibration_z", "0", CVAR_ARCHIVE};
+
+cvar_t gyro_noise_thresh = {"gyro_noise_thresh", "1.5", CVAR_ARCHIVE};
+
+static SDL_JoystickID		joy_active_instanceid = -1;
+static int					joy_active_device = -1;
+static SDL_GameController	*joy_active_controller = NULL;
+static gamepadtype_t		joy_active_type = GAMEPAD_NONE;
+static char					joy_active_name[256];
+static qboolean				joy_has_rumble = false;
+
+static qboolean	no_mouse = false;
+
+static const int buttonremap[] =
+{
+	K_MOUSE1,	/* left button		*/
+	K_MOUSE3,	/* middle button	*/
+	K_MOUSE2,	/* right button		*/
+	K_MOUSE4,	/* back button		*/
+	K_MOUSE5	/* forward button	*/
+};
+
+/* total accumulated mouse movement since last frame */
+static int		total_dx = 0, total_dy = 0;
+static float	gyro_yaw = 0.f, gyro_pitch = 0.f, gyro_raw_mag = 0.f;
+static float	gyro_center_frac = 0.f, gyro_center_amount = 0.f;
+
+// used for gyro calibration
+#define GYRO_CALIBRATION_SAMPLES	300
+static float gyro_accum[3] = {0.f, 0.f, 0.f};
+static unsigned int updates_countdown = 0;
+
+static qboolean gyro_present = false;
+static qboolean gyro_button_pressed = false;
+
+static struct
+{
+	float	yaw;
+	float	pitch;
+	float	yaw_delta;
+	float	prev_lerp_frac;
+	float	prev_angle;
+	float	prev_scale;
+} flick;
+
+static void IN_ResetFlickState (void)
+{
+	memset (&flick, 0, sizeof (flick));
+}
+
+static int SDLCALL IN_FilterMouseEvents (const SDL_Event *event)
+{
+	switch (event->type)
+	{
+	case SDL_MOUSEMOTION:
+	// case SDL_MOUSEBUTTONDOWN:
+	// case SDL_MOUSEBUTTONUP:
+		if (key_dest == key_menu)
+			M_Mousemove (event->motion.x, event->motion.y);
+		else if (key_dest == key_console)
+			Con_Mousemove (event->motion.x, event->motion.y);
+		return 0;
+	}
+
+	return 1;
+}
+
+static int SDLCALL IN_SDL2_FilterMouseEvents (void *userdata, SDL_Event *event)
+{
+	return IN_FilterMouseEvents (event);
+}
+
+void IN_ShowCursor (void)
+{
+	VID_SetMouseCursor (MOUSECURSOR_DEFAULT);
+
+	if (!SDL_GetRelativeMouseMode ())
+		return;
+	if (SDL_SetRelativeMouseMode (SDL_FALSE) != 0)
+		Con_Printf ("WARNING: could not disable relative mouse mode (%s).\n", SDL_GetError ());
+
+	if (!ui_mouse.value)
+	{
+		SDL_Window *window = (SDL_Window *) VID_GetWindow ();
+		int width, height;
+		SDL_GetWindowSize (window, &width, &height);
+		SDL_WarpMouseInWindow (window, width/2, height/2);
+	}
+}
+
+void IN_HideCursor (void)
+{
+#ifdef __APPLE__
+	{
+		// Work around https://github.com/sezero/quakespasm/issues/48
+		int width, height;
+		SDL_GetWindowSize((SDL_Window*) VID_GetWindow(), &width, &height);
+		SDL_WarpMouseInWindow((SDL_Window*) VID_GetWindow(), width / 2, height / 2);
+	}
+#endif
+	if (SDL_SetRelativeMouseMode(SDL_TRUE) != 0)
+		Con_Printf("WARNING: could not enable relative mouse mode (%s).\n", SDL_GetError());
+}
+
+static void IN_BeginIgnoringMouseEvents(void)
+{
+	SDL_EventFilter currentFilter = NULL;
+	void *currentUserdata = NULL;
+	SDL_GetEventFilter(&currentFilter, &currentUserdata);
+	if (currentFilter != IN_SDL2_FilterMouseEvents)
+		SDL_SetEventFilter(IN_SDL2_FilterMouseEvents, NULL);
+}
+
+static void IN_EndIgnoringMouseEvents(void)
+{
+	SDL_EventFilter currentFilter;
+	void *currentUserdata;
+	if (SDL_GetEventFilter(&currentFilter, &currentUserdata) == SDL_TRUE)
+		SDL_SetEventFilter(NULL, NULL);
+}
+
+#ifdef MACOS_X_ACCELERATION_HACK
+static cvar_t in_disablemacosxmouseaccel = {"in_disablemacosxmouseaccel", "1", CVAR_ARCHIVE};
+static double originalMouseSpeed = -1.0;
+
+static io_connect_t IN_GetIOHandle(void)
+{
+	io_connect_t iohandle = MACH_PORT_NULL;
+	io_service_t iohidsystem = MACH_PORT_NULL;
+	mach_port_t masterport;
+	kern_return_t status;
+
+	status = IOMasterPort(MACH_PORT_NULL, &masterport);
+	if (status != KERN_SUCCESS)
+		return 0;
+
+	iohidsystem = IORegistryEntryFromPath(masterport, kIOServicePlane ":/IOResources/IOHIDSystem");
+	if (!iohidsystem)
+		return 0;
+
+	status = IOServiceOpen(iohidsystem, mach_task_self(), kIOHIDParamConnectType, &iohandle);
+	IOObjectRelease(iohidsystem);
+
+	return iohandle;
+}
+
+static void IN_DisableOSXMouseAccel (void)
+{
+	io_connect_t mouseDev = IN_GetIOHandle();
+	if (mouseDev != 0)
+	{
+		if (IOHIDGetAccelerationWithKey(mouseDev, CFSTR(kIOHIDMouseAccelerationType), &originalMouseSpeed) == kIOReturnSuccess)
+		{
+			if (IOHIDSetAccelerationWithKey(mouseDev, CFSTR(kIOHIDMouseAccelerationType), -1.0) != kIOReturnSuccess)
+			{
+				Cvar_Set("in_disablemacosxmouseaccel", "0");
+				Con_Printf("WARNING: Could not disable mouse acceleration (failed at IOHIDSetAccelerationWithKey).\n");
+			}
+		}
+		else
+		{
+			Cvar_Set("in_disablemacosxmouseaccel", "0");
+			Con_Printf("WARNING: Could not disable mouse acceleration (failed at IOHIDGetAccelerationWithKey).\n");
+		}
+		IOServiceClose(mouseDev);
+	}
+	else
+	{
+		Cvar_Set("in_disablemacosxmouseaccel", "0");
+		Con_Printf("WARNING: Could not disable mouse acceleration (failed at IO_GetIOHandle).\n");
+	}
+}
+
+static void IN_ReenableOSXMouseAccel (void)
+{
+	io_connect_t mouseDev = IN_GetIOHandle();
+	if (mouseDev != 0)
+	{
+		if (IOHIDSetAccelerationWithKey(mouseDev, CFSTR(kIOHIDMouseAccelerationType), originalMouseSpeed) != kIOReturnSuccess)
+			Con_Printf("WARNING: Could not re-enable mouse acceleration (failed at IOHIDSetAccelerationWithKey).\n");
+		IOServiceClose(mouseDev);
+	}
+	else
+	{
+		Con_Printf("WARNING: Could not re-enable mouse acceleration (failed at IO_GetIOHandle).\n");
+	}
+	originalMouseSpeed = -1;
+}
+#endif /* MACOS_X_ACCELERATION_HACK */
+
+
+void IN_Activate (void)
+{
+	if (no_mouse)
+		return;
+
+#ifdef MACOS_X_ACCELERATION_HACK
+	/* Save the status of mouse acceleration */
+	if (originalMouseSpeed == -1 && in_disablemacosxmouseaccel.value)
+		IN_DisableOSXMouseAccel();
+#endif
+
+	IN_HideCursor();
+	IN_EndIgnoringMouseEvents();
+
+	total_dx = 0;
+	total_dy = 0;
+}
+
+void IN_Deactivate (qboolean free_cursor)
+{
+	if (no_mouse)
+		return;
+
+#ifdef MACOS_X_ACCELERATION_HACK
+	if (originalMouseSpeed != -1)
+		IN_ReenableOSXMouseAccel();
+#endif
+
+	if (free_cursor)
+		IN_ShowCursor();
+	else
+		IN_HideCursor();
+
+	/* discard all mouse events when input is deactivated */
+	IN_BeginIgnoringMouseEvents();
+}
+
+void IN_DeactivateForConsole (void)
+{
+	IN_Deactivate(true);
+}
+
+void IN_DeactivateForMenu (void)
+{
+	IN_Deactivate(modestate == MS_WINDOWED || ui_mouse.value);
+}
+
+static qboolean IN_UseController (int device_index)
+{
+	SDL_GameController *gamecontroller;
+	const char *controllername;
+
+	if (device_index == joy_active_device)
+		return true;
+
+	if (joy_active_device != -1)
+	{
+#if SDL_VERSION_ATLEAST (2, 0, 9)
+		if (joy_has_rumble)
+			SDL_GameControllerRumble (joy_active_controller, 0, 0, 100);
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+		if (SDL_GameControllerHasLED (joy_active_controller))
+			SDL_GameControllerSetLED (joy_active_controller, 0, 0, 0);
+#endif // SDL_VERSION_ATLEAST (2, 0, 14)
+#endif // SDL_VERSION_ATLEAST (2, 0, 9)
+		SDL_GameControllerClose (joy_active_controller);
+
+		// Only show "gamepad removed" message when disabling the gamepad altogether,
+		// not when switching to a different device
+		if (device_index == -1)
+			Con_Printf ("Gamepad removed: %s\n", joy_active_name);
+
+		joy_active_name[0] = '\0';
+		joy_active_controller = NULL;
+		joy_active_instanceid = -1;
+		joy_active_device = -1;
+		joy_active_type = GAMEPAD_NONE;
+		Cvar_SetValueQuick (&joy_device, -1);
+		gyro_present = false;
+		gyro_yaw = gyro_pitch = gyro_raw_mag = 0.f;
+		joy_has_rumble = false;
+		IN_ResetFlickState ();
+	}
+
+	if (device_index == -1)
+		return true;
+
+	if (device_index < 0 || device_index >= SDL_NumJoysticks ())
+		return false;
+
+	gamecontroller = SDL_GameControllerOpen (device_index);
+	if (!gamecontroller)
+	{
+		Con_Warning ("couldn't open gamepad device %d\n", device_index);
+		return false;
+	}
+
+	controllername = SDL_GameControllerName (gamecontroller);
+	if (!controllername)
+		controllername = "[Unknown gamepad]";
+	Con_Printf ("Using gamepad: %s\n", controllername);
+
+	joy_active_controller = gamecontroller;
+	joy_active_instanceid = SDL_JoystickInstanceID (SDL_GameControllerGetJoystick (gamecontroller));
+	joy_active_device = device_index;
+	Cvar_SetValueQuick (&joy_device, device_index);
+	// Save controller name so we can print it when unplugged (SDL_GameControllerName would return NULL)
+	q_strlcpy (joy_active_name, controllername, sizeof (joy_active_name));
+
+	// Save controller family so we can show more appropriate button names
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+	switch (SDL_GameControllerGetType (joy_active_controller))
+	{
+	default:
+	case SDL_CONTROLLER_TYPE_XBOX360:
+	case SDL_CONTROLLER_TYPE_XBOXONE:
+		joy_active_type = GAMEPAD_XBOX;
+		break;
+
+	case SDL_CONTROLLER_TYPE_PS3:
+	case SDL_CONTROLLER_TYPE_PS4:
+	case SDL_CONTROLLER_TYPE_PS5:
+		joy_active_type = GAMEPAD_PLAYSTATION;
+		break;
+
+	case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO:
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+	case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT:
+	case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT:
+	case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR:
+#endif // SDL_VERSION_ATLEAST(2, 24, 0)
+		joy_active_type = GAMEPAD_NINTENDO;
+		break;
+	}
+#else
+	// No controller type info (old SDL headers), assume Xbox-compatible
+	joy_active_type = GAMEPAD_XBOX;
+#endif // SDL_VERSION_ATLEAST(2, 0, 12)
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+	if (SDL_GameControllerHasLED (joy_active_controller))
+	{
+		// orange LED, seemed fitting for Quake
+		SDL_GameControllerSetLED (joy_active_controller, 80, 20, 0);
+	}
+	if (SDL_GameControllerHasSensor (joy_active_controller, SDL_SENSOR_GYRO)
+		&& !SDL_GameControllerSetSensorEnabled (joy_active_controller, SDL_SENSOR_GYRO, SDL_TRUE))
+	{
+		gyro_present = true;
+#if SDL_VERSION_ATLEAST(2, 0, 16)
+		Con_Printf ("Gyro sensor enabled at %g Hz\n", SDL_GameControllerGetSensorDataRate (joy_active_controller, SDL_SENSOR_GYRO));
+#else
+		Con_printf ("Gyro sensor enabled.\n")
+#endif // SDL_VERSION_ATLEAST(2, 0, 16)
+	}
+	else
+	{
+		Con_Printf ("Gyro sensor not found\n");
+	}
+#endif // SDL_VERSION_ATLEAST(2, 0, 14)
+
+#if SDL_VERSION_ATLEAST (2, 0, 9)
+	joy_has_rumble = SDL_GameControllerHasRumble (joy_active_controller);
+#endif // SDL_VERSION_ATLEAST (2, 0, 9)
+	return true;
+}
+
+static void IN_SetupJoystick (void)
+{
+	int	count = SDL_NumJoysticks ();
+	int	device_index = CLAMP (-1, (int)joy_device.value, count - 1);
+	IN_UseController (device_index);
+}
+
+static qboolean IN_RemapJoystick (void)
+{
+	int i, count;
+
+	if (joy_active_instanceid == -1)
+		return false;
+
+	for (i = 0, count = SDL_NumJoysticks (); i < count; i++)
+	{
+		if (SDL_JoystickGetDeviceInstanceID (i) == joy_active_instanceid)
+		{
+			joy_active_device = i;
+			Cvar_SetValueQuick (&joy_device, i);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void IN_StartupJoystick (void)
+{
+    int i;
+    int nummappings;
+    char controllerdb[MAX_OSPATH];
+
+    if (COM_CheckParm("-nojoy"))
+        return;
+
+#if SDL_VERSION_ATLEAST(2, 0, 12)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS5, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS4, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_SWITCH, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
+
+	// Enable rumble and motion sensors for PS4 and PS5 controllers while uder Bluetooth connectivitiy
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 23, 2)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_COMBINE_JOY_CONS, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 25, 1)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_PS3, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 26, 0)
+	SDL_SetHint (SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
+#endif
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+	SDL_SetHint (SDL_HINT_JOYSTICK_RAWINPUT, "1");
+	SDL_SetHint (SDL_HINT_JOYSTICK_RAWINPUT_CORRELATE_XINPUT, "1");
+#endif
+
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) == -1)
+    {
+        Con_Warning("could not initialize SDL Game Controller\n");
+        return;
+    }
+
+    // Load additional SDL2 controller definitions from gamecontrollerdb.txt
+    for (i = 0; i < com_numbasedirs; i++)
+    {
+        q_snprintf(controllerdb, sizeof(controllerdb), "%s/gamecontrollerdb.txt", com_basedirs[i]);
+        nummappings = SDL_GameControllerAddMappingsFromFile(controllerdb);
+        if (nummappings > 0)
+            Con_Printf("%d mappings loaded from gamecontrollerdb.txt\n", nummappings);
+    }
+
+    IN_SetupJoystick();
+}
+
+void IN_ShutdownJoystick (void)
+{
+	IN_UseController (-1);
+	SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+}
+
+qboolean IN_HasGamepad (void)
+{
+	return joy_active_controller != NULL;
+}
+
+const char *IN_GetGamepadName (void)
+{
+	return joy_active_controller ? joy_active_name : NULL;
+}
+
+gamepadtype_t IN_GetGamepadType (void)
+{
+	return joy_active_type;
+}
+
+void IN_UseNextGamepad (int dir, qboolean allow_disable)
+{
+	int i, j, numiter, numdev;
+
+	numdev = SDL_NumJoysticks ();
+	numiter = allow_disable ? numdev : numdev - 1;
+
+	for (i = 0, j = joy_active_device + dir; i < numiter; i++, j += dir)
+	{
+		if (j < -1)
+			j = numdev - 1;
+		else if (j < 0)
+			j = allow_disable ? -1 : numdev - 1;
+		else if (j >= numdev)
+			j = allow_disable ? -1 : 0;
+
+		if ((j == -1 || SDL_IsGameController (j)) && IN_UseController (j))
+			return;
+	}
+}
+
+qboolean IN_HasRumble (void)
+{
+	return joy_has_rumble;
+}
+
+void IN_GyroActionDown (void)
+{
+	gyro_button_pressed = true;
+}
+
+void IN_GyroActionUp (void)
+{
+	gyro_button_pressed = false;
+}
+
+/*
+================
+Joy_Device_f
+
+Called when joy_device changes
+================
+*/
+static void Joy_Device_f (cvar_t *cvar)
+{
+	if ((int)cvar->value != joy_active_device)
+		IN_SetupJoystick ();
+}
+
+/*
+================
+Joy_Device_Completion_f
+
+Tab completion for the joy_device cvar
+================
+*/
+static void Joy_Device_Completion_f (cvar_t *cvar, const char *partial)
+{
+	int i, count;
+
+	for (i = 0, count = SDL_NumJoysticks (); i < count; i++)
+		if (SDL_IsGameController (i))
+			Con_AddToTabList (va ("%d", i), partial, SDL_GameControllerNameForIndex (i));
+}
+
+/*
+================
+Joy_Flick_f
+
+Called when joy_flick changes
+================
+*/
+static void Joy_Flick_f (cvar_t *cvar)
+{
+	IN_ResetFlickState ();
+}
+
+/*
+================
+IN_UpdateSDLTextInput
+
+Calls SDL_StartTextInput/StopTextInput as needed
+based on textmode and the device type
+================
+*/
+static void IN_UpdateSDLTextInput (void)
+{
+	// For devices with an on-screen keyboard (e.g. Steam Deck) we only start text input
+	// if requested explicitly (TEXTMODE_ON) in order to avoid having the OSK pop up
+	// in searchable menus (Options, Maps, or Mods), which use emulated char events instead.
+	// For all the other devices we start text input if not disabled explicitly (TEXTMODE_OFF).
+	// In other words, TEXTMODE_NOPOPUP is treated as OFF on Steam Deck, ON on desktop.
+	qboolean enabled = SDL_HasScreenKeyboardSupport () ? textmode == TEXTMODE_ON : textmode != TEXTMODE_OFF;
+	if (enabled)
+		SDL_StartTextInput ();
+	else
+		SDL_StopTextInput ();
+}
+
+/*
+================
+IN_Init
+================
+*/
+void IN_Init (void)
+{
+	textmode = Key_TextEntry();
+	IN_UpdateSDLTextInput ();
+
+	if (safemode || COM_CheckParm("-nomouse"))
+	{
+		no_mouse = true;
+		/* discard all mouse events when input is deactivated */
+		IN_BeginIgnoringMouseEvents();
+	}
+
+#ifdef MACOS_X_ACCELERATION_HACK
+	Cvar_RegisterVariable(&in_disablemacosxmouseaccel);
+#endif
+	Cvar_RegisterVariable(&in_debugkeys);
+	Cvar_RegisterVariable(&joy_sensitivity_yaw);
+	Cvar_RegisterVariable(&joy_sensitivity_pitch);
+	Cvar_RegisterVariable(&joy_deadzone_look);
+	Cvar_RegisterVariable(&joy_deadzone_move);
+	Cvar_RegisterVariable(&joy_outer_threshold_look);
+	Cvar_RegisterVariable(&joy_outer_threshold_move);
+	Cvar_RegisterVariable(&joy_deadzone_trigger);
+	Cvar_RegisterVariable(&joy_invert);
+	Cvar_RegisterVariable(&joy_exponent);
+	Cvar_RegisterVariable(&joy_exponent_move);
+	Cvar_RegisterVariable(&joy_swapmovelook);
+	Cvar_RegisterVariable(&joy_flick);
+	Cvar_SetCallback (&joy_flick, Joy_Flick_f);
+	Cvar_RegisterVariable(&joy_flick_time);
+	Cvar_RegisterVariable(&joy_flick_recenter);
+	Cvar_RegisterVariable(&joy_flick_deadzone);
+	Cvar_RegisterVariable(&joy_flick_noise_thresh);
+	Cvar_RegisterVariable(&joy_flick_adjust_speed);
+	Cvar_RegisterVariable(&joy_rumble);
+	Cvar_RegisterVariable(&joy_device);
+	Cvar_SetCallback(&joy_device, Joy_Device_f);
+	Cvar_SetCompletion(&joy_device, Joy_Device_Completion_f);
+	Cvar_RegisterVariable(&joy_always_active);
+
+	Cvar_RegisterVariable(&gyro_enable);
+	Cvar_RegisterVariable(&gyro_mode);
+	Cvar_RegisterVariable(&gyro_turning_axis);
+
+	Cvar_RegisterVariable(&gyro_yawsensitivity);
+	Cvar_RegisterVariable(&gyro_pitchsensitivity);
+
+	Cvar_RegisterVariable(&gyro_calibration_x);
+	Cvar_RegisterVariable(&gyro_calibration_y);
+	Cvar_RegisterVariable(&gyro_calibration_z);
+	Cvar_RegisterVariable(&gyro_noise_thresh);
+
+	Cmd_AddCommand ("+gyroaction", IN_GyroActionDown);
+	Cmd_AddCommand ("-gyroaction", IN_GyroActionUp);
+
+	IN_Activate();
+	IN_StartupJoystick();
+	Sys_ActivateKeyFilter(true);
+}
+
+void IN_Shutdown (void)
+{
+	Sys_ActivateKeyFilter(false);
+	IN_Deactivate(true);
+	IN_ShutdownJoystick();
+}
+
+extern cvar_t v_centerspeed;
+extern cvar_t cl_maxpitch; /* johnfitz -- variable pitch clamping */
+extern cvar_t cl_minpitch; /* johnfitz -- variable pitch clamping */
+extern cvar_t scr_fov;
+
+static float IN_FovScale (void)
+{
+	return tan (DEG2RAD (r_refdef.basefov) * 0.5f) / tan (DEG2RAD (scr_fov.value) * 0.5f);
+}
+
+void IN_MouseMotion(int dx, int dy)
+{
+	if (!windowhasfocus)
+		dx = dy = 0;	//don't change view angles etc while unfocused.
+	if (cls.state != ca_connected || cls.signon != SIGNONS || key_dest != key_game || CL_InCutscene ())
+	{
+		total_dx = 0;
+		total_dy = 0;
+		return;
+	}
+	total_dx += dx;
+	total_dy += dy;
+}
+
+typedef struct joyaxis_s
+{
+	float x;
+	float y;
+} joyaxis_t;
+
+typedef struct joy_buttonstate_s
+{
+	qboolean buttondown[SDL_CONTROLLER_BUTTON_MAX];
+} joybuttonstate_t;
+
+typedef struct axisstate_s
+{
+	float axisvalue[SDL_CONTROLLER_AXIS_MAX]; // normalized to +-1
+} joyaxisstate_t;
+
+static joybuttonstate_t joy_buttonstate;
+static joyaxisstate_t joy_axisstate;
+
+static double joy_buttontimer[SDL_CONTROLLER_BUTTON_MAX];
+static double joy_emulatedkeytimer[6];
+
+#ifdef __WATCOMC__ /* OW1.9 doesn't have powf() / sqrtf() */
+#define powf pow
+#define sqrtf sqrt
+#endif
+
+/*
+================
+IN_AxisMagnitude
+
+Returns the vector length of the given joystick axis
+================
+*/
+static vec_t IN_AxisMagnitude(joyaxis_t axis)
+{
+	vec_t magnitude = sqrtf((axis.x * axis.x) + (axis.y * axis.y));
+	return magnitude;
+}
+
+/*
+================
+IN_ApplyEasing
+
+assumes axis values are in [-1, 1] and the vector magnitude has been clamped at 1.
+Raises the axis values to the given exponent, keeping signs.
+================
+*/
+static joyaxis_t IN_ApplyEasing(joyaxis_t axis, float exponent)
+{
+	joyaxis_t result = {0};
+	vec_t eased_magnitude;
+	vec_t magnitude = IN_AxisMagnitude(axis);
+	
+	if (magnitude == 0)
+		return result;
+	
+	eased_magnitude = powf(magnitude, exponent);
+	
+	result.x = axis.x * (eased_magnitude / magnitude);
+	result.y = axis.y * (eased_magnitude / magnitude);
+	return result;
+}
+
+/*
+================
+IN_ApplyDeadzone
+
+in: raw joystick axis values converted to floats in +-1
+out: applies a circular inner deadzone and a circular outer threshold and clamps the magnitude at 1
+     (my 360 controller is slightly non-circular and the stick travels further on the diagonals)
+
+deadzone is expected to satisfy 0 < deadzone < 1 - outer_threshold
+outer_threshold is expected to satisfy 0 < outer_threshold < 1 - deadzone
+
+from https://github.com/jeremiah-sypult/Quakespasm-Rift
+and adapted from http://www.third-helix.com/2013/04/12/doing-thumbstick-dead-zones-right.html
+================
+*/
+static joyaxis_t IN_ApplyDeadzone(joyaxis_t axis, float deadzone, float outer_threshold)
+{
+	joyaxis_t result = {0};
+	vec_t magnitude = IN_AxisMagnitude(axis);
+	
+	if ( magnitude > deadzone ) {
+		// rescale the magnitude so deadzone becomes 0, and 1-outer_threshold becomes 1
+		const vec_t new_magnitude = q_min(1.0, (magnitude - deadzone) / (1.0 - deadzone - outer_threshold));
+		const vec_t scale = new_magnitude / magnitude;
+		result.x = axis.x * scale;
+		result.y = axis.y * scale;
+	}
+	
+	return result;
+}
+
+/*
+================
+IN_KeyForControllerButton
+================
+*/
+static int IN_KeyForControllerButton(SDL_GameControllerButton button)
+{
+	switch (button)
+	{
+		case SDL_CONTROLLER_BUTTON_A: return K_ABUTTON;
+		case SDL_CONTROLLER_BUTTON_B: return K_BBUTTON;
+		case SDL_CONTROLLER_BUTTON_X: return K_XBUTTON;
+		case SDL_CONTROLLER_BUTTON_Y: return K_YBUTTON;
+		// Note: back and start are always mapped to TAB/ESC, the player cannot rebind them
+		case SDL_CONTROLLER_BUTTON_BACK: return K_TAB;
+		case SDL_CONTROLLER_BUTTON_GUIDE: return K_GUIDE;		
+		case SDL_CONTROLLER_BUTTON_START: return K_ESCAPE;
+		case SDL_CONTROLLER_BUTTON_LEFTSTICK: return K_LTHUMB;
+		case SDL_CONTROLLER_BUTTON_RIGHTSTICK: return K_RTHUMB;
+		case SDL_CONTROLLER_BUTTON_LEFTSHOULDER: return K_LSHOULDER;
+		case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: return K_RSHOULDER;
+		case SDL_CONTROLLER_BUTTON_DPAD_UP: return K_DPAD_UP;
+		case SDL_CONTROLLER_BUTTON_DPAD_DOWN: return K_DPAD_DOWN;
+		case SDL_CONTROLLER_BUTTON_DPAD_LEFT: return K_DPAD_LEFT;
+		case SDL_CONTROLLER_BUTTON_DPAD_RIGHT: return K_DPAD_RIGHT;
+		case SDL_CONTROLLER_BUTTON_MISC1: return K_MISC1;
+		case SDL_CONTROLLER_BUTTON_PADDLE1: return K_PADDLE1;
+		case SDL_CONTROLLER_BUTTON_PADDLE2: return K_PADDLE2;
+		case SDL_CONTROLLER_BUTTON_PADDLE3: return K_PADDLE3;
+		case SDL_CONTROLLER_BUTTON_PADDLE4: return K_PADDLE4;
+		case SDL_CONTROLLER_BUTTON_TOUCHPAD: return K_TOUCHPAD;
+		default: return 0;
+	}
+}
+
+/*
+================
+IN_JoyKeyEvent
+
+Sends a Key_Event if a unpressed -> pressed or pressed -> unpressed transition occurred,
+and generates key repeats if the button is held down.
+
+Adapted from DarkPlaces by lordhavoc
+================
+*/
+static void IN_JoyKeyEvent(qboolean wasdown, qboolean isdown, int key, double *timer)
+{
+	static const double repeatdelay = 0.5; // time (in seconds) between initial press and first repetition
+	static const double repeatrate = 32.0; // ticks per second
+
+	// we can't use `realtime` for key repeats because it is not monotomic
+	const double currenttime = Sys_DoubleTime();
+	
+	if (wasdown)
+	{
+		if (isdown)
+		{
+			if (currenttime >= *timer)
+			{
+				*timer = currenttime + 1.0 / repeatrate;
+				lastactivetype = KD_GAMEPAD;
+				Key_Event(key, true);
+			}
+		}
+		else
+		{
+			*timer = 0;
+			lastactivetype = KD_GAMEPAD;
+			Key_Event(key, false);
+		}
+	}
+	else
+	{
+		if (isdown)
+		{
+			*timer = currenttime + repeatdelay;
+			lastactivetype = KD_GAMEPAD;
+			Key_Event(key, true);
+		}
+	}
+}
+
+static joyaxis_t IN_GetLookAxis (joyaxisstate_t *state)
+{
+	joyaxis_t axis;
+	axis.x = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTX : SDL_CONTROLLER_AXIS_RIGHTX];
+	axis.y = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTY : SDL_CONTROLLER_AXIS_RIGHTY];
+	return axis;
+}
+
+static joyaxis_t IN_GetMoveAxis (joyaxisstate_t *state)
+{
+	joyaxis_t axis;
+	axis.x = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTX : SDL_CONTROLLER_AXIS_LEFTX];
+	axis.y = state->axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTY : SDL_CONTROLLER_AXIS_LEFTY];
+	return axis;
+}
+
+static qboolean IN_JoyActive (void)
+{
+	return joy_active_controller != NULL && (joy_always_active.value || lastactivetype == KD_GAMEPAD);
+}
+
+/*
+================
+IN_Commands
+
+Emit key events for game controller buttons, including emulated buttons for analog sticks/triggers
+================
+*/
+void IN_Commands (void)
+{
+	joyaxisstate_t newaxisstate;
+	int i;
+	const float stickthreshold = 0.9;
+	const float triggerthreshold = joy_deadzone_trigger.value;
+	
+	if (!joy_active_controller)
+		return;
+
+	// emit key events for controller buttons
+	for (i = 0; i < SDL_CONTROLLER_BUTTON_MAX; i++)
+	{
+		qboolean newstate = SDL_GameControllerGetButton(joy_active_controller, (SDL_GameControllerButton)i);
+		qboolean oldstate = joy_buttonstate.buttondown[i];
+		
+		joy_buttonstate.buttondown[i] = newstate;
+		
+		// NOTE: This can cause a reentrant call of IN_Commands, via SCR_ModalMessage when confirming a new game.
+		IN_JoyKeyEvent(oldstate, newstate, IN_KeyForControllerButton((SDL_GameControllerButton)i), &joy_buttontimer[i]);
+	}
+	
+	for (i = 0; i < SDL_CONTROLLER_AXIS_MAX; i++)
+	{
+		newaxisstate.axisvalue[i] = SDL_GameControllerGetAxis(joy_active_controller, (SDL_GameControllerAxis)i) / 32768.0f;
+	}
+	
+	// emit emulated arrow keys so the analog sticks can be used in the menu
+	if (key_dest != key_game)
+	{
+		joyaxis_t old_move = IN_GetMoveAxis (&joy_axisstate);
+		joyaxis_t new_move = IN_GetMoveAxis (&newaxisstate);
+		IN_JoyKeyEvent(old_move.x < -stickthreshold, new_move.x < -stickthreshold, K_LEFTARROW,		&joy_emulatedkeytimer[0]);
+		IN_JoyKeyEvent(old_move.x >  stickthreshold, new_move.x >  stickthreshold, K_RIGHTARROW,	&joy_emulatedkeytimer[1]);
+		IN_JoyKeyEvent(old_move.y < -stickthreshold, new_move.y < -stickthreshold, K_UPARROW,		&joy_emulatedkeytimer[2]);
+		IN_JoyKeyEvent(old_move.y >  stickthreshold, new_move.y >  stickthreshold, K_DOWNARROW,		&joy_emulatedkeytimer[3]);
+	}
+	else if (lastactivetype != KD_GAMEPAD)
+	{
+		if (IN_AxisMagnitude (IN_GetLookAxis (&newaxisstate)) > joy_deadzone_look.value ||
+			IN_AxisMagnitude (IN_GetMoveAxis (&newaxisstate)) > joy_deadzone_move.value)
+			lastactivetype = KD_GAMEPAD;
+	}
+
+	// scroll console with look stick
+	if (key_dest == key_console)
+	{
+		const float scrollthreshold = 0.1f;
+		const float maxscrollspeed = 72.f; // lines per second
+		const float scrollinterval = 1.f / maxscrollspeed; 
+		static double timer = 0.0;
+		joyaxis_t raw, deadzone, eased;
+		float scale;
+
+		raw = IN_GetLookAxis (&newaxisstate);
+		deadzone = IN_ApplyDeadzone (raw, joy_deadzone_look.value, joy_outer_threshold_look.value);
+		eased = IN_ApplyEasing (deadzone, joy_exponent.value);
+		if (joy_invert.value)
+			eased.y = -eased.y;
+
+		scale = fabs (eased.y);
+		if (scale > scrollthreshold)
+		{
+			scale = (scale - scrollthreshold) / (1.f - scrollthreshold);
+			timer -= scale * host_rawframetime;
+			if (timer < 0.0)
+			{
+				int ticks = (int) ceil (-timer / scrollinterval);
+				timer += ticks * scrollinterval;
+				Con_Scroll (eased.y < 0.0f ? ticks : -ticks);
+			}
+		}
+		else
+		{
+			timer = 0.0;
+		}
+	}
+
+	// emit emulated keys for the analog triggers
+	IN_JoyKeyEvent(joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERLEFT] > triggerthreshold,  newaxisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERLEFT] > triggerthreshold, K_LTRIGGER, &joy_emulatedkeytimer[4]);
+	IN_JoyKeyEvent(joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERRIGHT] > triggerthreshold, newaxisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERRIGHT] > triggerthreshold, K_RTRIGGER, &joy_emulatedkeytimer[5]);
+	
+	joy_axisstate = newaxisstate;
+
+#if SDL_VERSION_ATLEAST (2, 0, 9)
+	if (joy_has_rumble && !IN_IsCalibratingGyro () && joy_rumble.value > 0.f && IN_JoyActive ())
+	{
+		float strength = CLAMP (0.f, joy_rumble.value, 1.f) * 0xffff;
+		float lofreq = GetClampedFraction (S_GetLoFreqLevel (), 0.067f, 0.45f);
+		float hifreq = GetClampedFraction (S_GetHiFreqLevel (), 0.061f, 0.45f);
+		hifreq *= hifreq;
+		SDL_GameControllerRumble (joy_active_controller, lofreq * strength, hifreq * strength, 100);
+	}
+#endif // SDL_VERSION_ATLEAST (2, 0, 9)
+}
+
+/*
+================
+IN_FlickStickEasing
+================
+*/
+static float IN_FlickStickEasing (float frac)
+{
+	frac = 1.f - frac;
+	frac = 1.f - frac * frac;
+	return frac;
+}
+
+/*
+================
+IN_JoyMove
+================
+*/
+void IN_JoyMove (usercmd_t *cmd)
+{
+	float	speed;
+	joyaxis_t moveRaw, moveDeadzone, moveEased;
+	joyaxis_t lookRaw, lookDeadzone, lookEased;
+	extern	cvar_t	sv_maxspeed;
+
+	if (!joy_active_controller)
+		return;
+
+	if (cl.paused || key_dest != key_game)
+		return;
+
+	moveRaw = IN_GetMoveAxis (&joy_axisstate);
+	lookRaw = IN_GetLookAxis (&joy_axisstate);
+
+	moveDeadzone = IN_ApplyDeadzone(moveRaw, joy_deadzone_move.value, joy_outer_threshold_move.value);
+	lookDeadzone = IN_ApplyDeadzone(lookRaw, joy_deadzone_look.value, joy_outer_threshold_look.value);
+
+	moveEased = IN_ApplyEasing(moveDeadzone, joy_exponent_move.value);
+	lookEased = IN_ApplyEasing(lookDeadzone, joy_exponent.value);
+
+	if ((in_speed.state & 1) ^ (cl_alwaysrun.value != 0.0 || cl_forwardspeed.value >= sv_maxspeed.value))
+		// running
+		speed = sv_maxspeed.value;
+	else if (cl_forwardspeed.value >= sv_maxspeed.value)
+		// not running, with always run = vanilla
+		speed = q_min(sv_maxspeed.value, cl_forwardspeed.value / cl_movespeedkey.value);
+	else
+		// not running, with always run = off or quakespasm
+		speed = cl_forwardspeed.value;
+
+	cmd->sidemove += speed * moveEased.x;
+	cmd->forwardmove -= speed * moveEased.y;
+
+	if (CL_InCutscene ())
+		return;
+
+	// handle flick stick if enabled
+	if (joy_flick.value && gyro_present && gyro_enable.value)
+	{
+		float		angle, scale, lerp_frac, delta;
+		qboolean	isactive, wasactive;
+
+		// get current stick position in polar coordinates
+		angle = NormalizeAngle (RAD2DEG (atan2 (lookRaw.y, lookRaw.x)) + 90.f);
+		scale = IN_AxisMagnitude (lookRaw);
+
+		// handle state transitions
+		isactive = scale > joy_flick_deadzone.value;
+		wasactive = flick.prev_scale > joy_flick_deadzone.value;
+		if (isactive != wasactive)
+		{
+			if (!wasactive) // start new flick
+			{
+				flick.prev_lerp_frac = 0.f;
+				flick.yaw = angle;
+				flick.pitch = cl.viewangles[PITCH];
+			}
+		}
+		else if (isactive) // continuous adjustments
+		{
+			delta = AngleDifference (angle, flick.prev_angle);
+			if (joy_flick_noise_thresh.value > 0.f) // filter small movements
+			{
+				float filter_scale = fabs (delta) / joy_flick_noise_thresh.value;
+				if (filter_scale < 1.f)
+				{
+					filter_scale = LERP (0.05f, 1.f, filter_scale * filter_scale);
+					delta *= filter_scale;
+					angle = NormalizeAngle (flick.prev_angle + delta);
+				}
+			}
+			flick.yaw_delta += delta;
+		}
+
+		// apply yaw adjustment
+		if (joy_flick_adjust_speed.value > 0.f)
+			delta = flick.yaw_delta * q_min (1.0, host_rawframetime * joy_flick_adjust_speed.value);
+		else
+			delta = flick.yaw_delta;
+		if (fabs (delta) > 0.01)
+		{
+			cl.viewangles[YAW] -= delta;
+			flick.yaw_delta -= delta;
+		}
+
+		// advance angle animation
+		if (joy_flick_time.value > 0.f)
+		{
+			lerp_frac = flick.prev_lerp_frac + host_rawframetime / joy_flick_time.value;
+			lerp_frac = CLAMP (0.f, lerp_frac, 1.f);
+		}
+		else
+			lerp_frac = 1.f;
+
+		delta = IN_FlickStickEasing (lerp_frac) - IN_FlickStickEasing (flick.prev_lerp_frac);
+		cl.viewangles[YAW] -= flick.yaw * delta;
+		cl.viewangles[PITCH] -= flick.pitch * delta * CLAMP (0.f, joy_flick_recenter.value, 1.f);
+
+		// update state
+		flick.prev_scale = scale;
+		flick.prev_angle = angle;
+		flick.prev_lerp_frac = lerp_frac;
+	}
+	else // traditional joystick look
+	{
+		IN_ResetFlickState ();
+
+		cl.viewangles[YAW] -= lookEased.x * joy_sensitivity_yaw.value * host_rawframetime;
+		cl.viewangles[PITCH] += lookEased.y * joy_sensitivity_pitch.value * (joy_invert.value ? -1.0 : 1.0) * host_rawframetime;
+
+		if (lookEased.x != 0 || lookEased.y != 0)
+			V_StopPitchDrift();
+	}
+
+	/* johnfitz -- variable pitch clamping */
+	if (cl.viewangles[PITCH] > cl_maxpitch.value)
+		cl.viewangles[PITCH] = cl_maxpitch.value;
+	if (cl.viewangles[PITCH] < cl_minpitch.value)
+		cl.viewangles[PITCH] = cl_minpitch.value;
+}
+
+static float IN_RecenterEasing (float frac)
+{
+	return frac * frac;
+}
+
+void IN_GyroMove(usercmd_t *cmd)
+{
+	float scale, duration, lerp_frac;
+	if (!gyro_enable.value)
+		return;
+
+	if (!IN_JoyActive ())
+		return;
+
+	if (cl.paused || key_dest != key_game)
+		return;
+
+	if (CL_InCutscene ())
+		return;
+
+	scale = (180.f / M_PI) * host_rawframetime * IN_FovScale ();
+	switch ((int)gyro_mode.value)
+	{
+	case GYRO_BUTTON_DISABLES:
+		if (gyro_button_pressed)
+			return;
+		break;
+	case GYRO_BUTTON_ENABLES:
+		if (!gyro_button_pressed)
+			return;
+		break;
+	case GYRO_BUTTON_INVERTS_DIR:
+		if (gyro_button_pressed)
+			scale = -scale;
+		break;
+	default:
+		break;
+	}
+
+	// apply gyro
+	cl.viewangles[YAW] += scale * gyro_yaw * gyro_yawsensitivity.value;
+	cl.viewangles[PITCH] -= scale * gyro_pitch * gyro_pitchsensitivity.value;
+
+	// Default pitch drift code tries to move towards the ideal pitch
+	// every frame, which means it is always fighting the player's input.
+	// When gyro is active we disable the default behavior, and instead
+	// we perform "additive" camera centering by storing the delta
+	// between the ideal pitch and the current pitch when centerview is used,
+	// and injecting that delta over some amount of time.
+
+	// stop standard pitch drifting
+	V_StopPitchDrift ();
+
+	// store angle delta and reset centering anim if centerview was used this frame
+	if (cl.lastcenterstart == cl.time)
+	{
+		gyro_center_frac = 0.f;
+		gyro_center_amount = cl.idealpitch - cl.viewangles[PITCH];
+	}
+
+	// try to roughly mimic the look of the default pitch drift code
+	if (gyro_center_amount != 0.f && v_centerspeed.value > 0.f)
+	{
+		duration = fabs (gyro_center_amount / v_centerspeed.value);
+		lerp_frac = gyro_center_frac + host_rawframetime / duration;
+		lerp_frac = CLAMP (0.f, lerp_frac, 1.f);
+	}
+	else
+		lerp_frac = 1.f;
+	scale = IN_RecenterEasing (lerp_frac) - IN_RecenterEasing (gyro_center_frac);
+	gyro_center_frac = lerp_frac;
+	cl.viewangles[PITCH] += gyro_center_amount * scale;
+
+	/* johnfitz -- variable pitch clamping */
+	if (cl.viewangles[PITCH] > cl_maxpitch.value)
+		cl.viewangles[PITCH] = cl_maxpitch.value;
+	if (cl.viewangles[PITCH] < cl_minpitch.value)
+		cl.viewangles[PITCH] = cl_minpitch.value;
+}
+
+void IN_MouseMove(usercmd_t *cmd)
+{
+	float		dmx, dmy;
+	float		sens;
+	qboolean	mlook = (in_mlook.state & 1) || freelook.value;
+
+	sens = sensitivity.value * IN_FovScale ();
+
+	dmx = total_dx * sens;
+	dmy = total_dy * sens;
+
+	total_dx = 0;
+	total_dy = 0;
+
+	if ((in_strafe.state & 1) || (lookstrafe.value && mlook))
+		cmd->sidemove += m_side.value * dmx;
+	else
+		cl.viewangles[YAW] -= m_yaw.value * dmx;
+
+	if (mlook)
+	{
+		if (dmx || dmy)
+			V_StopPitchDrift ();
+	}
+
+	if (mlook && !(in_strafe.state & 1))
+	{
+		cl.viewangles[PITCH] += m_pitch.value * dmy;
+		/* johnfitz -- variable pitch clamping */
+		if (cl.viewangles[PITCH] > cl_maxpitch.value)
+			cl.viewangles[PITCH] = cl_maxpitch.value;
+		if (cl.viewangles[PITCH] < cl_minpitch.value)
+			cl.viewangles[PITCH] = cl_minpitch.value;
+	}
+	else
+	{
+		if ((in_strafe.state & 1) && noclip_anglehack)
+			cmd->upmove -= m_forward.value * dmy;
+		else
+			cmd->forwardmove -= m_forward.value * dmy;
+	}
+}
+
+void IN_Move(usercmd_t *cmd)
+{
+	IN_JoyMove(cmd);
+	IN_GyroMove(cmd);
+	IN_MouseMove(cmd);
+}
+
+void IN_ClearStates (void)
+{
+}
+
+void IN_UpdateInputMode (void)
+{
+	textmode_t want_textmode = Key_TextEntry();
+	if (textmode != want_textmode)
+	{
+		textmode = want_textmode;
+		IN_UpdateSDLTextInput ();
+	}
+}
+
+qboolean IN_EmulatedCharEvents (void)
+{
+	return textmode == TEXTMODE_NOPOPUP && !SDL_IsTextInputActive ();
+}
+
+keydevice_t IN_GetLastActiveDeviceType (void)
+{
+	return lastactivetype;
+}
+
+static inline int IN_SDL2_ScancodeToQuakeKey(SDL_Scancode scancode)
+{
+	switch (scancode)
+	{
+	case SDL_SCANCODE_TAB: return K_TAB;
+	case SDL_SCANCODE_RETURN: return K_ENTER;
+	case SDL_SCANCODE_RETURN2: return K_ENTER;
+	case SDL_SCANCODE_ESCAPE: return K_ESCAPE;
+	case SDL_SCANCODE_SPACE: return K_SPACE;
+
+	case SDL_SCANCODE_A: return 'a';
+	case SDL_SCANCODE_B: return 'b';
+	case SDL_SCANCODE_C: return 'c';
+	case SDL_SCANCODE_D: return 'd';
+	case SDL_SCANCODE_E: return 'e';
+	case SDL_SCANCODE_F: return 'f';
+	case SDL_SCANCODE_G: return 'g';
+	case SDL_SCANCODE_H: return 'h';
+	case SDL_SCANCODE_I: return 'i';
+	case SDL_SCANCODE_J: return 'j';
+	case SDL_SCANCODE_K: return 'k';
+	case SDL_SCANCODE_L: return 'l';
+	case SDL_SCANCODE_M: return 'm';
+	case SDL_SCANCODE_N: return 'n';
+	case SDL_SCANCODE_O: return 'o';
+	case SDL_SCANCODE_P: return 'p';
+	case SDL_SCANCODE_Q: return 'q';
+	case SDL_SCANCODE_R: return 'r';
+	case SDL_SCANCODE_S: return 's';
+	case SDL_SCANCODE_T: return 't';
+	case SDL_SCANCODE_U: return 'u';
+	case SDL_SCANCODE_V: return 'v';
+	case SDL_SCANCODE_W: return 'w';
+	case SDL_SCANCODE_X: return 'x';
+	case SDL_SCANCODE_Y: return 'y';
+	case SDL_SCANCODE_Z: return 'z';
+
+	case SDL_SCANCODE_1: return '1';
+	case SDL_SCANCODE_2: return '2';
+	case SDL_SCANCODE_3: return '3';
+	case SDL_SCANCODE_4: return '4';
+	case SDL_SCANCODE_5: return '5';
+	case SDL_SCANCODE_6: return '6';
+	case SDL_SCANCODE_7: return '7';
+	case SDL_SCANCODE_8: return '8';
+	case SDL_SCANCODE_9: return '9';
+	case SDL_SCANCODE_0: return '0';
+
+	case SDL_SCANCODE_MINUS: return '-';
+	case SDL_SCANCODE_EQUALS: return '=';
+	case SDL_SCANCODE_LEFTBRACKET: return '[';
+	case SDL_SCANCODE_RIGHTBRACKET: return ']';
+	case SDL_SCANCODE_BACKSLASH: return '\\';
+	case SDL_SCANCODE_NONUSHASH: return '#';
+	case SDL_SCANCODE_SEMICOLON: return ';';
+	case SDL_SCANCODE_APOSTROPHE: return '\'';
+	case SDL_SCANCODE_GRAVE: return '`';
+	case SDL_SCANCODE_COMMA: return ',';
+	case SDL_SCANCODE_PERIOD: return '.';
+	case SDL_SCANCODE_SLASH: return '/';
+	case SDL_SCANCODE_NONUSBACKSLASH: return '\\';
+
+	case SDL_SCANCODE_BACKSPACE: return K_BACKSPACE;
+	case SDL_SCANCODE_UP: return K_UPARROW;
+	case SDL_SCANCODE_DOWN: return K_DOWNARROW;
+	case SDL_SCANCODE_LEFT: return K_LEFTARROW;
+	case SDL_SCANCODE_RIGHT: return K_RIGHTARROW;
+
+	case SDL_SCANCODE_LALT: return K_ALT;
+	case SDL_SCANCODE_RALT: return K_ALT;
+	case SDL_SCANCODE_LCTRL: return K_CTRL;
+	case SDL_SCANCODE_RCTRL: return K_CTRL;
+	case SDL_SCANCODE_LSHIFT: return K_SHIFT;
+	case SDL_SCANCODE_RSHIFT: return K_SHIFT;
+
+	case SDL_SCANCODE_F1: return K_F1;
+	case SDL_SCANCODE_F2: return K_F2;
+	case SDL_SCANCODE_F3: return K_F3;
+	case SDL_SCANCODE_F4: return K_F4;
+	case SDL_SCANCODE_F5: return K_F5;
+	case SDL_SCANCODE_F6: return K_F6;
+	case SDL_SCANCODE_F7: return K_F7;
+	case SDL_SCANCODE_F8: return K_F8;
+	case SDL_SCANCODE_F9: return K_F9;
+	case SDL_SCANCODE_F10: return K_F10;
+	case SDL_SCANCODE_F11: return K_F11;
+	case SDL_SCANCODE_F12: return K_F12;
+	case SDL_SCANCODE_INSERT: return K_INS;
+	case SDL_SCANCODE_DELETE: return K_DEL;
+	case SDL_SCANCODE_PAGEDOWN: return K_PGDN;
+	case SDL_SCANCODE_PAGEUP: return K_PGUP;
+	case SDL_SCANCODE_HOME: return K_HOME;
+	case SDL_SCANCODE_END: return K_END;
+
+	case SDL_SCANCODE_NUMLOCKCLEAR: return K_KP_NUMLOCK;
+	case SDL_SCANCODE_KP_DIVIDE: return K_KP_SLASH;
+	case SDL_SCANCODE_KP_MULTIPLY: return K_KP_STAR;
+	case SDL_SCANCODE_KP_MINUS: return K_KP_MINUS;
+	case SDL_SCANCODE_KP_7: return K_KP_HOME;
+	case SDL_SCANCODE_KP_8: return K_KP_UPARROW;
+	case SDL_SCANCODE_KP_9: return K_KP_PGUP;
+	case SDL_SCANCODE_KP_PLUS: return K_KP_PLUS;
+	case SDL_SCANCODE_KP_4: return K_KP_LEFTARROW;
+	case SDL_SCANCODE_KP_5: return K_KP_5;
+	case SDL_SCANCODE_KP_6: return K_KP_RIGHTARROW;
+	case SDL_SCANCODE_KP_1: return K_KP_END;
+	case SDL_SCANCODE_KP_2: return K_KP_DOWNARROW;
+	case SDL_SCANCODE_KP_3: return K_KP_PGDN;
+	case SDL_SCANCODE_KP_ENTER: return K_KP_ENTER;
+	case SDL_SCANCODE_KP_0: return K_KP_INS;
+	case SDL_SCANCODE_KP_PERIOD: return K_KP_DEL;
+
+	case SDL_SCANCODE_LGUI: return K_COMMAND;
+	case SDL_SCANCODE_RGUI: return K_COMMAND;
+
+	case SDL_SCANCODE_CAPSLOCK: return K_CAPSLOCK;
+	case SDL_SCANCODE_SCROLLLOCK: return K_SCROLLLOCK;
+
+	case SDL_SCANCODE_PRINTSCREEN: return K_PRINTSCREEN;
+
+	case SDL_SCANCODE_PAUSE: return K_PAUSE;
+
+	default: return 0;
+	}
+}
+
+static void IN_DebugTextEvent(SDL_Event *event)
+{
+	Con_Printf ("SDL_TEXTINPUT '%s' time: %g\n", event->text.text, Sys_DoubleTime());
+}
+
+static void IN_DebugKeyEvent(SDL_Event *event)
+{
+	const char *eventtype = (event->key.state == SDL_PRESSED) ? "SDL_KEYDOWN" : "SDL_KEYUP";
+	Con_Printf ("%s scancode: '%s' keycode: '%s' time: %g\n",
+		eventtype,
+		SDL_GetScancodeName(event->key.keysym.scancode),
+		SDL_GetKeyName(event->key.keysym.sym),
+		Sys_DoubleTime());
+}
+
+void IN_StartGyroCalibration (void)
+{
+#if SDL_VERSION_ATLEAST (2, 0, 9)
+	// Disable rumble temporarily
+	if (joy_has_rumble)
+		SDL_GameControllerRumble (joy_active_controller, 0, 0, 100);
+#endif // SDL_VERSION_ATLEAST (2, 0, 9)
+
+	gyro_accum[0] = 0.0;
+	gyro_accum[1] = 0.0;
+	gyro_accum[2] = 0.0;
+
+	updates_countdown = GYRO_CALIBRATION_SAMPLES;
+
+	// Note: we modify updates_countdown first, before printing the message to the console,
+	// because Con_Printf triggers a redraw, which in turn calls M_Calibration_Draw,
+	// which would see that updates_countown is 0 and consider that calibration must be done.
+	// Alternatively, we could use Con_SafePrintf (which doesn't refresh the screen).
+
+	Con_Printf ("Calibrating, please wait...\n");
+}
+
+static qboolean IN_UpdateGyroCalibration (const float newsample[3])
+{
+	if (!updates_countdown)
+		return false;
+
+	gyro_accum[0] += newsample[0];
+	gyro_accum[1] += newsample[1];
+	gyro_accum[2] += newsample[2];
+
+	updates_countdown--;
+	if (!updates_countdown)
+	{
+		const float inverseSamples = 1.f / GYRO_CALIBRATION_SAMPLES;
+		Cvar_SetValue("gyro_calibration_x", gyro_accum[0] * inverseSamples);
+		Cvar_SetValue("gyro_calibration_y", gyro_accum[1] * inverseSamples);
+		Cvar_SetValue("gyro_calibration_z", gyro_accum[2] * inverseSamples);
+
+		Con_Printf("Calibration results:\n X=%f Y=%f Z=%f\n",
+			gyro_calibration_x.value,
+			gyro_calibration_y.value,
+			gyro_calibration_z.value);
+
+		Con_Printf("Calibration finished\n");
+
+		return false;
+	}
+
+	return true;
+}
+
+qboolean IN_HasGyro (void)
+{
+	return gyro_present;
+}
+
+float IN_GetRawGyroMagnitude (void)
+{
+	if (!gyro_present)
+		return 0.f;
+	return gyro_raw_mag;
+}
+
+float IN_GetRawLookMagnitude (void)
+{
+	joyaxis_t axis;
+	if (!joy_active_controller)
+		return 0.f;
+
+	axis.x = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTX : SDL_CONTROLLER_AXIS_RIGHTX];
+	axis.y = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_LEFTY : SDL_CONTROLLER_AXIS_RIGHTY];
+
+	return IN_AxisMagnitude (axis);
+}
+
+float IN_GetRawMoveMagnitude (void)
+{
+	joyaxis_t axis;
+	if (!joy_active_controller)
+		return 0.f;
+
+	axis.x = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTX : SDL_CONTROLLER_AXIS_LEFTX];
+	axis.y = joy_axisstate.axisvalue[joy_swapmovelook.value ? SDL_CONTROLLER_AXIS_RIGHTY : SDL_CONTROLLER_AXIS_LEFTY];
+
+	return IN_AxisMagnitude (axis);
+}
+
+float IN_GetRawTriggerMagnitude (void)
+{
+	float left, right;
+	if (!joy_active_controller)
+		return 0.f;
+
+	left = fabs (joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERLEFT]);
+	right = fabs (joy_axisstate.axisvalue[SDL_CONTROLLER_AXIS_TRIGGERRIGHT]);
+
+	return q_max (left, right);
+
+}
+
+qboolean IN_IsCalibratingGyro (void)
+{
+	return updates_countdown != 0;
+}
+
+float IN_GetGyroCalibrationProgress (void)
+{
+	return (GYRO_CALIBRATION_SAMPLES - updates_countdown) / (float) GYRO_CALIBRATION_SAMPLES;
+}
+
+static float IN_FilterGyroSample (float prev, float cur)
+{
+	float thresh = DEG2RAD (gyro_noise_thresh.value);
+	float d = fabs (cur - prev);
+	if (d < thresh)
+	{
+		d /= thresh;
+		cur = LERP (prev, cur, 0.01f + 0.99f * d * d);
+	}
+	return cur;
+}
+
+void IN_SendKeyEvents (void)
+{
+	SDL_Event event;
+	int key;
+	qboolean down;
+
+	while (SDL_PollEvent(&event))
+	{
+		switch (event.type)
+		{
+		case SDL_WINDOWEVENT:
+			if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
+			{
+				Sys_ActivateKeyFilter(true);
+				windowhasfocus = true;
+				S_UnblockSound();
+			}
+			else if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+			{
+				windowhasfocus = false;
+				S_BlockSound();
+				Sys_ActivateKeyFilter(false);
+			}
+			else if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+			{
+				vid.width = event.window.data1;
+				vid.height = event.window.data2;
+				vid.resized = true;
+			}
+			break;
+		case SDL_TEXTINPUT:
+			lastactivetype = KD_KEYBOARD;
+
+			if (in_debugkeys.value)
+				IN_DebugTextEvent(&event);
+
+		// SDL2: We use SDL_TEXTINPUT for typing in the console / chat.
+		// SDL2 uses the local keyboard layout and handles modifiers
+		// (shift for uppercase, etc.) for us.
+			{
+				unsigned char *ch;
+				for (ch = (unsigned char *)event.text.text; *ch; ch++)
+					if ((*ch & ~0x7F) == 0)
+						Char_Event (*ch);
+			}
+			break;
+		case SDL_KEYDOWN:
+		case SDL_KEYUP:
+			down = (event.key.state == SDL_PRESSED);
+
+			lastactivetype = KD_KEYBOARD;
+
+			if (in_debugkeys.value)
+				IN_DebugKeyEvent(&event);
+
+		// SDL2: we interpret the keyboard as the US layout, so keybindings
+		// are based on key position, not the label on the key cap.
+			key = IN_SDL2_ScancodeToQuakeKey(event.key.keysym.scancode);
+
+		// also pass along the underlying keycode using the proper current layout for Y/N prompts.
+			Key_EventWithKeycode (key, down, event.key.keysym.sym);
+			break;
+
+		case SDL_MOUSEBUTTONDOWN:
+		case SDL_MOUSEBUTTONUP:
+			if (event.button.button < 1 ||
+			    event.button.button > Q_COUNTOF(buttonremap))
+			{
+				Con_Printf ("Ignored event for mouse button %d\n",
+							event.button.button);
+				break;
+			}
+			lastactivetype = KD_MOUSE;
+			if (key_dest == key_menu)
+				M_Mousemove (event.button.x, event.button.y);
+			else if (key_dest == key_console)
+				Con_Mousemove (event.button.x, event.button.y);
+			Key_Event(buttonremap[event.button.button - 1], event.button.state == SDL_PRESSED);
+			break;
+
+		case SDL_MOUSEWHEEL:
+			lastactivetype = KD_MOUSE;
+			if (event.wheel.y > 0)
+			{
+				Key_Event(K_MWHEELUP, true);
+				Key_Event(K_MWHEELUP, false);
+			}
+			else if (event.wheel.y < 0)
+			{
+				Key_Event(K_MWHEELDOWN, true);
+				Key_Event(K_MWHEELDOWN, false);
+			}
+			break;
+
+		case SDL_MOUSEMOTION:
+			IN_MouseMotion(event.motion.xrel, event.motion.yrel);
+			break;
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+		case SDL_CONTROLLERSENSORUPDATE:
+			if (event.csensor.sensor == SDL_SENSOR_GYRO && event.csensor.which == joy_active_instanceid)
+			{
+				float prev_yaw = gyro_yaw;
+				float prev_pitch = gyro_pitch;
+
+				if (IN_UpdateGyroCalibration (event.csensor.data))
+					break;
+
+				if (!gyro_turning_axis.value)
+					gyro_yaw = event.csensor.data[1] - gyro_calibration_y.value; // yaw
+				else
+					gyro_yaw = -(event.csensor.data[2] - gyro_calibration_z.value); // roll
+				gyro_pitch = event.csensor.data[0] - gyro_calibration_x.value;
+
+				// Save unfiltered magnitude to display in the UI
+				gyro_raw_mag = RAD2DEG (sqrt (gyro_yaw*gyro_yaw + gyro_pitch*gyro_pitch));
+
+				gyro_yaw = IN_FilterGyroSample (prev_yaw, gyro_yaw);
+				gyro_pitch = IN_FilterGyroSample (prev_pitch, gyro_pitch);
+			}
+			break;
+
+#endif // SDL_VERSION_ATLEAST(2, 0, 14)
+
+		case SDL_CONTROLLERDEVICEADDED:
+			if (!IN_RemapJoystick ())
+				IN_UseController (event.jdevice.which);
+			break;
+		case SDL_CONTROLLERDEVICEREMOVED:
+		case SDL_CONTROLLERDEVICEREMAPPED:
+			if (!IN_RemapJoystick ())
+				IN_SetupJoystick ();
+			break;
+#if SDL_VERSION_ATLEAST (2, 0, 14)
+		case SDL_LOCALECHANGED:
+			if (!q_strcasecmp (language.string, "auto"))
+				language.callback (&language);
+			break;
+#endif
+
+		case SDL_QUIT:
+			CL_Disconnect ();
+			Sys_Quit ();
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+

--- a/Quake/keys.c
+++ b/Quake/keys.c
@@ -1,0 +1,1489 @@
+/*
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2002-2009 John Fitzgibbons and others
+Copyright (C) 2007-2008 Kristian Duske
+Copyright (C) 2010-2014 QuakeSpasm developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#include "quakedef.h"
+#include "arch_def.h"
+#include "q_ctype.h"
+
+/* key up events are sent even if in console mode */
+
+#define		HISTORY_FILE_NAME "history.txt"
+
+char		key_lines[CMDLINES][MAXCMDLINE];
+char		key_tabhint[MAXCMDLINE];
+
+int		key_linepos;
+int		key_insert = 1;	//johnfitz -- insert key toggle (for editing)
+double		key_blinktime; //johnfitz -- fudge cursor blinking to make it easier to spot in certain cases
+
+int		edit_line = 0;
+int		history_line = 0;
+
+keydest_t	key_dest;
+
+char		*keybindings[MAX_KEYS];
+qboolean	consolekeys[MAX_KEYS];	// if true, can't be rebound while in console
+qboolean	menubound[MAX_KEYS];	// if true, can't be rebound while in menu
+qboolean	keydown[MAX_KEYS];
+
+typedef struct
+{
+	const char	*name;
+	int		keynum;
+} keyname_t;
+
+static const keyname_t keynames[] =
+{
+	{"TAB", K_TAB},
+	{"ENTER", K_ENTER},
+	{"ESCAPE", K_ESCAPE},
+	{"SPACE", K_SPACE},
+	{"BACKSPACE", K_BACKSPACE},
+	{"UPARROW", K_UPARROW},
+	{"DOWNARROW", K_DOWNARROW},
+	{"LEFTARROW", K_LEFTARROW},
+	{"RIGHTARROW", K_RIGHTARROW},
+
+	{"ALT", K_ALT},
+	{"CTRL", K_CTRL},
+	{"SHIFT", K_SHIFT},
+
+	{"KP_NUMLOCK", K_KP_NUMLOCK},
+	{"KP_SLASH", K_KP_SLASH},
+	{"KP_STAR", K_KP_STAR},
+	{"KP_MINUS", K_KP_MINUS},
+	{"KP_HOME", K_KP_HOME},
+	{"KP_UPARROW", K_KP_UPARROW},
+	{"KP_PGUP", K_KP_PGUP},
+	{"KP_PLUS", K_KP_PLUS},
+	{"KP_LEFTARROW", K_KP_LEFTARROW},
+	{"KP_5", K_KP_5},
+	{"KP_RIGHTARROW", K_KP_RIGHTARROW},
+	{"KP_END", K_KP_END},
+	{"KP_DOWNARROW", K_KP_DOWNARROW},
+	{"KP_PGDN", K_KP_PGDN},
+	{"KP_ENTER", K_KP_ENTER},
+	{"KP_INS", K_KP_INS},
+	{"KP_DEL", K_KP_DEL},
+
+	{"F1", K_F1},
+	{"F2", K_F2},
+	{"F3", K_F3},
+	{"F4", K_F4},
+	{"F5", K_F5},
+	{"F6", K_F6},
+	{"F7", K_F7},
+	{"F8", K_F8},
+	{"F9", K_F9},
+	{"F10", K_F10},
+	{"F11", K_F11},
+	{"F12", K_F12},
+
+	{"INS", K_INS},
+	{"DEL", K_DEL},
+	{"PGDN", K_PGDN},
+	{"PGUP", K_PGUP},
+	{"HOME", K_HOME},
+	{"END", K_END},
+
+	{"COMMAND", K_COMMAND},
+
+	{"CAPSLOCK", K_CAPSLOCK},
+	{"SCROLLLOCK", K_SCROLLLOCK},
+	{"NUMLOCK", K_KP_NUMLOCK}, // Note: added a second time, without the KP_ prefix, for consistency with the other LOCK keys
+
+	{"PRINTSCREEN", K_PRINTSCREEN},
+
+	{"MOUSE1", K_MOUSE1},
+	{"MOUSE2", K_MOUSE2},
+	{"MOUSE3", K_MOUSE3},
+	{"MOUSE4", K_MOUSE4},
+	{"MOUSE5", K_MOUSE5},
+
+	{"PAUSE", K_PAUSE},
+
+	{"MWHEELUP", K_MWHEELUP},
+	{"MWHEELDOWN", K_MWHEELDOWN},
+
+	{"SEMICOLON", ';'},	// because a raw semicolon seperates commands
+
+	{"BACKQUOTE", '`'},	// because a raw backquote may toggle the console
+	{"TILDE", '~'},		// because a raw tilde may toggle the console
+
+	{"LTHUMB", K_LTHUMB},
+	{"RTHUMB", K_RTHUMB},
+	{"LSHOULDER", K_LSHOULDER},
+	{"RSHOULDER", K_RSHOULDER},
+	{"DPAD_UP", K_DPAD_UP},
+	{"DPAD_DOWN", K_DPAD_DOWN},
+	{"DPAD_LEFT", K_DPAD_LEFT},
+	{"DPAD_RIGHT", K_DPAD_RIGHT},
+	{"ABUTTON", K_ABUTTON},
+	{"BBUTTON", K_BBUTTON},
+	{"XBUTTON", K_XBUTTON},
+	{"YBUTTON", K_YBUTTON},
+	{"GUIDE", K_GUIDE},	
+	{"LTRIGGER", K_LTRIGGER},
+	{"RTRIGGER", K_RTRIGGER},
+	{"MISC1", K_MISC1},
+	{"PADDLE1", K_PADDLE1},
+	{"PADDLE2", K_PADDLE2},
+	{"PADDLE3", K_PADDLE3},
+	{"PADDLE4", K_PADDLE4},
+	{"TOUCHPAD", K_TOUCHPAD},
+
+	// Gamepad "Start" and "Back" buttons are always mapped to ESC/TAB.
+	// We don't expose the key names in order to avoid having the player bind them in the console.
+	//{"JOY_START", K_START},
+	//{"JOY_BACK", K_BACK},
+
+	{NULL,		0}
+};
+
+static const char *const xbox_names[K_GAMEPAD_COUNT] =
+{
+	#define GAMEPAD_KEY_NAME(keycode, value, xboxname, psname, nintendoname) xboxname,
+	GAMEPAD_KEY_LIST (GAMEPAD_KEY_NAME)
+	#undef GAMEPAD_KEY_NAME
+};
+
+static const char *const ps_names[K_GAMEPAD_COUNT] =
+{
+	#define GAMEPAD_KEY_NAME(keycode, value, xboxname, psname, nintendoname) psname,
+	GAMEPAD_KEY_LIST (GAMEPAD_KEY_NAME)
+	#undef GAMEPAD_KEY_NAME
+};
+
+static const char *const nintendo_names[K_GAMEPAD_COUNT] =
+{
+	#define GAMEPAD_KEY_NAME(keycode, value, xboxname, psname, nintendoname) nintendoname,
+	GAMEPAD_KEY_LIST (GAMEPAD_KEY_NAME)
+	#undef GAMEPAD_KEY_NAME
+};
+
+/*
+==============================================================================
+
+			LINE TYPING INTO THE CONSOLE
+
+==============================================================================
+*/
+
+static void PasteToConsole (void)
+{
+	char *cbd, *p, *workline;
+	int mvlen, inslen;
+
+	if (key_linepos == MAXCMDLINE - 1)
+		return;
+
+	if ((cbd = PL_GetClipboardData()) == NULL)
+		return;
+
+	p = cbd;
+	while (*p)
+	{
+		if (*p == '\n' || *p == '\r' || *p == '\b')
+		{
+			*p = 0;
+			break;
+		}
+		p++;
+	}
+
+	inslen = (int) (p - cbd);
+	if (inslen + key_linepos > MAXCMDLINE - 1)
+		inslen = MAXCMDLINE - 1 - key_linepos;
+	if (inslen <= 0) goto done;
+
+	workline = key_lines[edit_line];
+	workline += key_linepos;
+	mvlen = (int) strlen(workline);
+	if (mvlen + inslen + key_linepos > MAXCMDLINE - 1)
+	{
+		mvlen = MAXCMDLINE - 1 - key_linepos - inslen;
+		if (mvlen < 0) mvlen = 0;
+	}
+
+	// insert the string
+	if (mvlen != 0)
+		memmove (workline + inslen, workline, mvlen);
+	memcpy (workline, cbd, inslen);
+	key_linepos += inslen;
+	workline[mvlen + inslen] = '\0';
+  done:
+	Z_Free(cbd);
+}
+
+static qboolean Key_IsWordSeparator (char c)
+{
+	switch (c)
+	{
+	case ' ':
+	case '_':
+	case '\t':
+	case ';':
+		return true;
+	default:
+		return false;
+	}
+}
+
+static int Key_FindWordBoundary (int dir)
+{
+	char	*workline = key_lines[edit_line];
+	int		len = (int) strlen (workline);
+	int		pos = key_linepos;
+
+	if (dir < 0)
+	{
+		while (pos > 1 && Key_IsWordSeparator (workline[pos - 1]))
+			pos--;
+		while (pos > 1 && !Key_IsWordSeparator (workline[pos - 1]))
+			pos--;
+	}
+	else
+	{
+		while (pos < len && !Key_IsWordSeparator (workline[pos]))
+			pos++;
+		while (pos < len && Key_IsWordSeparator (workline[pos]))
+			pos++;
+	}
+
+	return pos;
+}
+
+/*
+====================
+Key_Console -- johnfitz -- heavy revision
+
+Interactive line editing and console scrollback
+====================
+*/
+extern	char *con_text, key_tabpartial[MAXCMDLINE];
+extern	int con_current, con_linewidth, con_vislines;
+
+void Key_Console (int key)
+{
+	static	char current[MAXCMDLINE] = "";
+	int	history_line_last;
+	size_t		len;
+	char *workline = key_lines[edit_line];
+
+	switch (key)
+	{
+	case K_ENTER:
+	case K_KP_ENTER:
+	case K_ABUTTON:
+		key_tabpartial[0] = 0;
+		Cbuf_AddText (workline + 1);	// skip the prompt
+		Cbuf_AddText ("\n");
+		Con_Printf ("%s\n", workline);
+
+		// If the last two lines are identical, skip storing this line in history 
+		// by not incrementing edit_line
+		if (strcmp(workline, key_lines[(edit_line - 1) & (CMDLINES - 1)]))
+			edit_line = (edit_line + 1) & (CMDLINES - 1);
+
+		history_line = edit_line;
+		key_lines[edit_line][0] = ']';
+		key_lines[edit_line][1] = 0; //johnfitz -- otherwise old history items show up in the new edit line
+		key_linepos = 1;
+		key_tabhint[0] = '\0';
+		if (cls.state == ca_disconnected)
+			SCR_UpdateScreen (); // force an update, because the command may take some time
+		return;
+
+	case K_TAB:
+		Con_TabComplete (TABCOMPLETE_USER);
+		return;
+
+	case K_BACKSPACE:
+		key_tabpartial[0] = 0;
+		if (key_linepos > 1)
+		{
+			int numchars = keydown[K_CTRL] ? key_linepos - Key_FindWordBoundary (-1) : 1;
+			SDL_assert (numchars > 0);
+			workline += key_linepos - numchars;
+			len = strlen (workline);
+			SDL_assert ((int)len >= numchars);
+			memmove (workline, workline + numchars, len + 1 - numchars);
+			key_linepos -= numchars;
+			Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		}
+		return;
+
+	case K_DEL:
+		key_tabpartial[0] = 0;
+		workline += key_linepos;
+		if (*workline)
+		{
+			int numchars = keydown[K_CTRL] ? Key_FindWordBoundary (1) - key_linepos : 1;
+			SDL_assert (numchars > 0);
+			len = strlen (workline);
+			SDL_assert ((int)len >= numchars);
+			memmove (workline, workline + numchars, len + 1 - numchars);
+			Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		}
+		return;
+
+	case K_HOME:
+		if (keydown[K_CTRL])
+		{
+			//skip initial empty lines
+			int i, x;
+			char *line;
+
+			for (i = con_current - con_totallines + 1; i <= con_current; i++)
+			{
+				line = con_text + (i % con_totallines) * con_linewidth;
+				for (x = 0; x < con_linewidth; x++)
+				{
+					if (line[x] != ' ')
+						break;
+				}
+				if (x != con_linewidth)
+					break;
+			}
+			con_backscroll = CLAMP(0, con_current-i%con_totallines-2, con_totallines-(glheight>>3)-1);
+		}
+		else	key_linepos = 1;
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		Con_ForceMouseMove ();
+		return;
+
+	case K_END:
+		if (keydown[K_CTRL])
+			con_backscroll = 0;
+		else	key_linepos = strlen(workline);
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		Con_ForceMouseMove ();
+		return;
+
+	case K_PGUP:
+	case K_MWHEELUP:
+		Con_Scroll (keydown[K_CTRL] ? ((con_vislines>>3) - 4) : 2);
+		return;
+
+	case K_PGDN:
+	case K_MWHEELDOWN:
+		Con_Scroll (keydown[K_CTRL] ? -((con_vislines>>3) - 4) : -2);
+		return;
+
+	case K_LEFTARROW:
+	case K_DPAD_LEFT:
+		if (key_linepos > 1)
+		{
+			if (keydown[K_CTRL])
+				key_linepos = Key_FindWordBoundary (-1);
+			else
+				key_linepos--;
+			key_blinktime = realtime;
+			Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		}
+		return;
+
+	case K_RIGHTARROW:
+	case K_DPAD_RIGHT:
+		len = strlen(workline);
+		if ((int)len == key_linepos)
+		{
+			len = strlen(key_lines[(edit_line + (CMDLINES - 1)) & (CMDLINES - 1)]);
+			if ((int)len <= key_linepos)
+				return; // no character to get
+			workline += key_linepos;
+			*workline = key_lines[(edit_line + (CMDLINES - 1)) & (CMDLINES - 1)][key_linepos];
+			workline[1] = 0;
+			key_linepos++;
+		}
+		else
+		{
+			if (keydown[K_CTRL])
+				key_linepos = Key_FindWordBoundary (1);
+			else
+				key_linepos++;
+			key_blinktime = realtime;
+		}
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		return;
+
+	case K_UPARROW:
+	case K_DPAD_UP:
+		if (history_line == edit_line)
+			Q_strcpy(current, workline);
+
+		history_line_last = history_line;
+		do
+		{
+			history_line = (history_line - 1) & (CMDLINES - 1);
+		} while (history_line != edit_line && !key_lines[history_line][1]);
+
+		if (history_line == edit_line)
+		{
+			history_line = history_line_last;
+			return;
+		}
+
+		key_tabpartial[0] = 0;
+		len = strlen(key_lines[history_line]);
+		memmove(workline, key_lines[history_line], len+1);
+		key_linepos = (int)len;
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		return;
+
+	case K_DOWNARROW:
+	case K_DPAD_DOWN:
+		if (history_line == edit_line)
+			return;
+
+		key_tabpartial[0] = 0;
+
+		do
+		{
+			history_line = (history_line + 1) & (CMDLINES - 1);
+		} while (history_line != edit_line && !key_lines[history_line][1]);
+
+		if (history_line == edit_line)
+		{
+			len = strlen(current);
+			memcpy(workline, current, len+1);
+		}
+		else
+		{
+			len = strlen(key_lines[history_line]);
+			memmove(workline, key_lines[history_line], len+1);
+		}
+		key_linepos = (int)len;
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		return;
+
+	case K_INS:
+		if (keydown[K_SHIFT])		/* Shift-Ins paste */
+			PasteToConsole();
+		else if (keydown[K_CTRL])
+		{
+			Con_CopySelectionToClipboard ();
+			return;
+		}
+		else	key_insert ^= 1;
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+		return;
+
+	case 'v':
+	case 'V':
+#if defined(PLATFORM_OSX) || defined(PLATFORM_MAC)
+		if (keydown[K_COMMAND]) {	/* Cmd+v paste (Mac-only) */
+			PasteToConsole();
+			Con_TabComplete (TABCOMPLETE_AUTOHINT);
+			return;
+		}
+#endif
+		if (keydown[K_CTRL]) {		/* Ctrl+v paste */
+			PasteToConsole();
+			Con_TabComplete (TABCOMPLETE_AUTOHINT);
+			return;
+		}
+		break;
+
+	case 'a':
+	case 'A':
+		if (keydown[K_CTRL]) {		/* Ctrl+A: select whole buffer */
+			Con_SelectAll();
+			return;
+		}
+		break;
+
+	case 'c':
+	case 'C':
+		if (keydown[K_CTRL]) {		/* Ctrl+C: abort the line -- S.A */
+			if (Con_CopySelectionToClipboard ())
+				return;
+			Con_Printf ("%s\n", workline);
+			workline[0] = ']';
+			workline[1] = 0;
+			key_linepos = 1;
+			history_line= edit_line;
+			key_tabhint[0] = '\0';
+			return;
+		}
+		break;
+	}
+}
+
+void Char_Console (int key)
+{
+	size_t		len;
+	char *workline = key_lines[edit_line];
+
+	if (key_linepos < MAXCMDLINE-1)
+	{
+		qboolean endpos = !workline[key_linepos];
+
+		key_tabpartial[0] = 0; //johnfitz
+		// if inserting, move the text to the right
+		if (key_insert && !endpos)
+		{
+			workline[MAXCMDLINE - 2] = 0;
+			workline += key_linepos;
+			len = strlen(workline) + 1;
+			#if defined(__GNUC__) && (__GNUC__ > 7)
+			#pragma GCC diagnostic ignored "-Warray-bounds"
+			#endif
+			memmove (workline + 1, workline, len);
+			#if defined(__GNUC__) && (__GNUC__ > 7)
+			#pragma GCC diagnostic pop
+			#endif
+			*workline = key;
+		}
+		else
+		{
+			workline += key_linepos;
+			*workline = key;
+			// null terminate if at the end
+			if (endpos)
+				workline[1] = 0;
+		}
+		key_linepos++;
+
+		Con_TabComplete (TABCOMPLETE_AUTOHINT);
+	}
+}
+
+//============================================================================
+
+qboolean	chat_team = false;
+static char	chat_buffer[MAXCMDLINE];
+static int	chat_bufferlen = 0;
+
+const char *Key_GetChatBuffer (void)
+{
+	return chat_buffer;
+}
+
+int Key_GetChatMsgLen (void)
+{
+	return chat_bufferlen;
+}
+
+void Key_EndChat (void)
+{
+	key_dest = key_game;
+	chat_bufferlen = 0;
+	chat_buffer[0] = 0;
+}
+
+void Key_Message (int key)
+{
+	switch (key)
+	{
+	case K_ENTER:
+	case K_KP_ENTER:
+		if (chat_team)
+			Cbuf_AddText ("say_team \"");
+		else
+			Cbuf_AddText ("say \"");
+		Cbuf_AddText(chat_buffer);
+		Cbuf_AddText("\"\n");
+
+		Key_EndChat ();
+		return;
+
+	case K_ESCAPE:
+		Key_EndChat ();
+		return;
+
+	case K_BACKSPACE:
+		if (chat_bufferlen)
+			chat_buffer[--chat_bufferlen] = 0;
+		return;
+	}
+}
+
+void Char_Message (int key)
+{
+	if (chat_bufferlen == sizeof(chat_buffer) - 1)
+		return; // all full
+
+	chat_buffer[chat_bufferlen++] = key;
+	chat_buffer[chat_bufferlen] = 0;
+}
+
+//============================================================================
+
+
+/*
+===================
+Key_StringToKeynum
+
+Returns a key number to be used to index keybindings[] by looking at
+the given string.  Single ascii characters return themselves, while
+the K_* names are matched up.
+===================
+*/
+int Key_StringToKeynum (const char *str)
+{
+	const keyname_t *kn;
+
+	if (!str || !str[0])
+		return -1;
+	if (!str[1])
+		return q_tolower (str[0]);
+
+	for (kn=keynames ; kn->name ; kn++)
+	{
+		if (!q_strcasecmp(str,kn->name))
+			return kn->keynum;
+	}
+	return -1;
+}
+
+/*
+===================
+Key_KeynumToString
+
+Returns a string (either a single ascii char, or a K_* name) for the
+given keynum.
+FIXME: handle quote special (general escape sequence?)
+===================
+*/
+const char *Key_KeynumToString (int keynum)
+{
+	static	char	tinystr[128][2];
+	const keyname_t	*kn;
+
+	if (keynum == -1)
+		return "<KEY NOT FOUND>";
+	if (keynum > 32 && keynum < 127)
+	{	// printable ascii
+		tinystr[keynum][0] = q_tolower (keynum);
+		tinystr[keynum][1] = 0;
+		return tinystr[keynum];
+	}
+
+	for (kn = keynames; kn->name; kn++)
+	{
+		if (keynum == kn->keynum)
+			return kn->name;
+	}
+
+	return "<UNKNOWN KEYNUM>";
+}
+
+/*
+===================
+Key_KeynumToFriendlyString
+
+Returns a user-facing string for the given keynum.
+===================
+*/
+const char *Key_KeynumToFriendlyString (int keynum)
+{
+	if (keynum >= K_GAMEPAD_BEGIN && keynum < K_GAMEPAD_END)
+	{
+		const char *str = NULL;
+
+		switch (IN_GetGamepadType ())
+		{
+		default:
+		case GAMEPAD_XBOX:			str = xbox_names		[keynum - K_GAMEPAD_BEGIN]; break;
+		case GAMEPAD_PLAYSTATION:	str = ps_names			[keynum - K_GAMEPAD_BEGIN]; break;
+		case GAMEPAD_NINTENDO:		str = nintendo_names	[keynum - K_GAMEPAD_BEGIN]; break;
+		}
+
+		if (str && *str)
+			return str;
+	}
+
+	return Key_KeynumToString (keynum);
+}
+
+
+/*
+===================
+Key_SetBinding
+===================
+*/
+void Key_SetBinding (int keynum, const char *binding)
+{
+	if (keynum == -1)
+		return;
+
+// free old bindings
+	if (keybindings[keynum])
+	{
+		Z_Free (keybindings[keynum]);
+		keybindings[keynum] = NULL;
+	}
+
+// allocate memory for new binding
+	if (binding)
+		keybindings[keynum] = Z_Strdup(binding);
+}
+
+/*
+===================
+Key_GetDeviceForKeynum
+===================
+*/
+keydevice_t Key_GetDeviceForKeynum (int keynum)
+{
+	if (keynum < 0 || keynum >= NUM_KEYCODES)
+		return KD_NONE;
+	if (keynum >= K_MOUSE_BEGIN && keynum < K_MOUSE_END)
+		return KD_MOUSE;
+	if (keynum >= K_GAMEPAD_BEGIN && keynum < K_GAMEPAD_END)
+		return KD_GAMEPAD;
+	return KD_KEYBOARD;
+}
+
+/*
+===================
+Key_GetDeviceMaskForKeynum
+===================
+*/
+keydevicemask_t Key_GetDeviceMaskForKeynum (int keynum)
+{
+	keydevice_t device = Key_GetDeviceForKeynum (keynum);
+	return device == KD_NONE ? KDM_NONE : (keydevicemask_t) (1 << (int)device);
+}
+
+/*
+===================
+Key_GetKeysForCommand
+===================
+*/
+int Key_GetKeysForCommand (const char *command, int *keys, int maxkeys, keydevicemask_t devmask)
+{
+	int i, count;
+
+	if (maxkeys <= 0)
+		return 0;
+
+	for (i = 0; i < maxkeys; i++)
+		keys[i] = -1;
+	count = 0;
+
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (keybindings[i] && !strcmp (keybindings[i], command))
+		{
+			if ((Key_GetDeviceMaskForKeynum (i) & devmask) == 0)
+				continue;
+			keys[count++] = i;
+			if (count == maxkeys)
+				break;
+		}
+	}
+
+	return count;
+}
+
+/*
+===================
+Key_Unbind_f
+===================
+*/
+void Key_Unbind_f (void)
+{
+	int	b;
+
+	if (Cmd_Argc() != 2)
+	{
+		Con_Printf ("unbind <key> : remove commands from a key\n");
+		return;
+	}
+
+	b = Key_StringToKeynum (Cmd_Argv(1));
+	if (b == -1)
+	{
+		Con_Printf ("\"%s\" isn't a valid key\n", Cmd_Argv(1));
+		return;
+	}
+
+	Key_SetBinding (b, NULL);
+}
+
+void Key_Unbindall_f (void)
+{
+	int	i;
+
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (keybindings[i])
+			Key_SetBinding (i, NULL);
+	}
+}
+
+/*
+============
+Key_Bindlist_f -- johnfitz
+============
+*/
+void Key_Bindlist_f (void)
+{
+	int	i, count;
+
+	count = 0;
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (keybindings[i] && *keybindings[i])
+		{
+			Con_SafePrintf ("   %s \"%s\"\n", Key_KeynumToString(i), keybindings[i]);
+			count++;
+		}
+	}
+	Con_SafePrintf ("%i bindings\n", count);
+}
+
+/*
+===================
+Key_Bind_f
+===================
+*/
+void Key_Bind_f (void)
+{
+	int	i, c, b;
+	char	cmd[1024];
+
+	c = Cmd_Argc();
+
+	if (c < 2)
+	{
+		Con_Printf ("bind <key> [command] : attach a command to a key\n");
+		return;
+	}
+	b = Key_StringToKeynum (Cmd_Argv(1));
+	if (b == -1)
+	{
+		Con_Printf ("\"%s\" isn't a valid key\n", Cmd_Argv(1));
+		return;
+	}
+
+	if (c == 2)
+	{
+		if (keybindings[b])
+			Con_Printf ("\"%s\" = \"%s\"\n", Cmd_Argv(1), keybindings[b] );
+		else
+			Con_Printf ("\"%s\" is not bound\n", Cmd_Argv(1) );
+		return;
+	}
+
+// copy the rest of the command line
+	cmd[0] = 0;
+	for (i = 2; i < c; i++)
+	{
+		q_strlcat (cmd, Cmd_Argv(i), sizeof(cmd));
+		if (i != (c-1))
+			q_strlcat (cmd, " ", sizeof(cmd));
+	}
+
+	Key_SetBinding (b, cmd);
+}
+
+/*
+============
+Key_WriteBindings
+
+Writes lines containing "bind key value"
+============
+*/
+void Key_WriteBindings (FILE *f)
+{
+	int	i;
+
+	// unbindall before loading stored bindings:
+	if (cfg_unbindall.value)
+		fprintf (f, "unbindall\n");
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (keybindings[i] && *keybindings[i])
+			fprintf (f, "bind \"%s\" \"%s\"\n", Key_KeynumToString(i), keybindings[i]);
+	}
+}
+
+
+void History_Init (void)
+{
+	int i, c;
+	FILE *hf;
+
+	for (i = 0; i < CMDLINES; i++)
+	{
+		key_lines[i][0] = ']';
+		key_lines[i][1] = 0;
+	}
+	key_linepos = 1;
+
+	hf = Sys_fopen(va("%s/%s", host_parms->userdir, HISTORY_FILE_NAME), "rt");
+	if (hf != NULL)
+	{
+		do
+		{
+			i = 1;
+			do
+			{
+				c = fgetc(hf);
+				key_lines[edit_line][i++] = c;
+			} while (c != '\r' && c != '\n' && c != EOF && i < MAXCMDLINE);
+			key_lines[edit_line][i - 1] = 0;
+			edit_line = (edit_line + 1) & (CMDLINES - 1);
+			/* for people using a windows-generated history file on unix: */
+			if (c == '\r' || c == '\n')
+			{
+				do
+					c = fgetc(hf);
+				while (c == '\r' || c == '\n');
+				if (c != EOF)
+					ungetc(c, hf);
+				else	c = 0; /* loop once more, otherwise last line is lost */
+			}
+		} while (c != EOF && edit_line < CMDLINES);
+		fclose(hf);
+
+		history_line = edit_line = (edit_line - 1) & (CMDLINES - 1);
+		key_lines[edit_line][0] = ']';
+		key_lines[edit_line][1] = 0;
+	}
+}
+
+void History_Shutdown (void)
+{
+	int i;
+	FILE *hf;
+
+	hf = Sys_fopen(va("%s/%s", host_parms->userdir, HISTORY_FILE_NAME), "wt");
+	if (hf != NULL)
+	{
+		i = edit_line;
+		do
+		{
+			i = (i + 1) & (CMDLINES - 1);
+		} while (i != edit_line && !key_lines[i][1]);
+
+		while (i != edit_line && key_lines[i][1])
+		{
+			fprintf(hf, "%s\n", key_lines[i] + 1);
+			i = (i + 1) & (CMDLINES - 1);
+		}
+		fclose(hf);
+	}
+}
+
+/*
+===================
+Key_Init
+===================
+*/
+void Key_Init (void)
+{
+	int	i;
+
+	History_Init ();
+
+	key_blinktime = realtime; //johnfitz
+
+//
+// initialize consolekeys[]
+//
+	for (i = 32; i < 127; i++) // ascii characters
+		consolekeys[i] = true;
+	consolekeys['`'] = false;
+	consolekeys['~'] = false;
+	consolekeys[K_TAB] = true;
+	consolekeys[K_ENTER] = true;
+	consolekeys[K_ESCAPE] = true;
+	consolekeys[K_BACKSPACE] = true;
+	consolekeys[K_UPARROW] = true;
+	consolekeys[K_DOWNARROW] = true;
+	consolekeys[K_LEFTARROW] = true;
+	consolekeys[K_RIGHTARROW] = true;
+	consolekeys[K_DPAD_UP] = true;
+	consolekeys[K_DPAD_DOWN] = true;
+	consolekeys[K_DPAD_LEFT] = true;
+	consolekeys[K_DPAD_RIGHT] = true;
+	consolekeys[K_CTRL] = true;
+	consolekeys[K_SHIFT] = true;
+	consolekeys[K_INS] = true;
+	consolekeys[K_DEL] = true;
+	consolekeys[K_PGDN] = true;
+	consolekeys[K_PGUP] = true;
+	consolekeys[K_HOME] = true;
+	consolekeys[K_END] = true;
+	consolekeys[K_KP_NUMLOCK] = true;
+	consolekeys[K_KP_SLASH] = true;
+	consolekeys[K_KP_STAR] = true;
+	consolekeys[K_KP_MINUS] = true;
+	consolekeys[K_KP_HOME] = true;
+	consolekeys[K_KP_UPARROW] = true;
+	consolekeys[K_KP_PGUP] = true;
+	consolekeys[K_KP_PLUS] = true;
+	consolekeys[K_KP_LEFTARROW] = true;
+	consolekeys[K_KP_5] = true;
+	consolekeys[K_KP_RIGHTARROW] = true;
+	consolekeys[K_KP_END] = true;
+	consolekeys[K_KP_DOWNARROW] = true;
+	consolekeys[K_KP_PGDN] = true;
+	consolekeys[K_KP_ENTER] = true;
+	consolekeys[K_KP_INS] = true;
+	consolekeys[K_KP_DEL] = true;
+	consolekeys[K_MOUSE1] = true;
+#if defined(PLATFORM_OSX) || defined(PLATFORM_MAC)
+	consolekeys[K_COMMAND] = true;
+#endif
+	consolekeys[K_MWHEELUP] = true;
+	consolekeys[K_MWHEELDOWN] = true;
+	consolekeys[K_ABUTTON] = true;
+
+//
+// initialize menubound[]
+//
+	menubound[K_ESCAPE] = true;
+	menubound[K_PRINTSCREEN] = true;
+	for (i = 0; i < 12; i++)
+		menubound[K_F1+i] = true;
+
+//
+// register our functions
+//
+	Cmd_AddCommand ("bindlist",Key_Bindlist_f); //johnfitz
+	Cmd_AddCommand ("bind",Key_Bind_f);
+	Cmd_AddCommand ("unbind",Key_Unbind_f);
+	Cmd_AddCommand ("unbindall",Key_Unbindall_f);
+}
+
+static struct {
+	qboolean active;
+	int lastkey;
+	int lastchar;
+} key_inputgrab = { false, -1, -1 };
+
+/*
+===================
+Key_BeginInputGrab
+===================
+*/
+void Key_BeginInputGrab (void)
+{
+	Key_ClearStates ();
+
+	key_inputgrab.active = true;
+	key_inputgrab.lastkey = -1;
+	key_inputgrab.lastchar = -1;
+
+	IN_UpdateInputMode ();
+}
+
+/*
+===================
+Key_EndInputGrab
+===================
+*/
+void Key_EndInputGrab (void)
+{
+	Key_ClearStates ();
+
+	key_inputgrab.active = false;
+
+	IN_UpdateInputMode ();
+}
+
+/*
+===================
+Key_GetGrabbedInput
+===================
+*/
+void Key_GetGrabbedInput (int *lastkey, int *lastchar)
+{
+	if (lastkey)
+		*lastkey = key_inputgrab.lastkey;
+	if (lastchar)
+		*lastchar = key_inputgrab.lastchar;
+}
+
+/*
+===================
+Key_Event
+
+Called by the system between frames for both key up and key down events
+Should NOT be called during an interrupt!
+===================
+*/
+void Key_Event (int key, qboolean down)
+{
+	Key_EventWithKeycode (key, down, 0);
+}
+
+/*
+===================
+Key_EventWithKeycode
+
+Called by the system between frames for both key up and key down events
+Should NOT be called during an interrupt!
+keycode parameter should have the key's actual keycode using the current keyboard layout,
+not necessarily the US-keyboard-based scancode. Pass 0 if not applicable.
+===================
+*/
+void Key_EventWithKeycode (int key, qboolean down, int keycode)
+{
+	char	*kb;
+	char	cmd[1024];
+	qboolean wasdown;
+
+	if (key < 0 || key >= MAX_KEYS)
+		return;
+
+// handle fullscreen toggle
+	if (down && (key == K_ENTER || key == K_KP_ENTER) && keydown[K_ALT])
+	{
+		VID_Toggle();
+		return;
+	}
+
+// handle autorepeats and stray key up events
+	if (down)
+	{
+		if (keydown[key])
+		{
+			if (key_dest == key_game && !con_forcedup)
+				return; // ignore autorepeats in game mode
+		}
+		else if (key >= 200 && !keybindings[key] && key_dest == key_game && !cls.demoplayback)
+		{
+			int optkey;
+			if (Key_GetKeysForCommand ("menu_options", &optkey, 1, KDM_ANY))
+				Con_Printf ("%s is unbound, hit %s to set.\n", Key_KeynumToFriendlyString (key), Key_KeynumToFriendlyString (optkey));
+			else
+				Con_Printf ("%s is unbound, use Options menu to set.\n", Key_KeynumToFriendlyString (key));
+		}
+	}
+	else if (!keydown[key])
+		return; // ignore stray key up events
+
+	wasdown = keydown[key];
+	keydown[key] = down;
+
+	if (key_inputgrab.active)
+	{
+		if (down)
+		{
+			key_inputgrab.lastkey = key;
+			if (keycode > 0)
+				key_inputgrab.lastchar = keycode;
+		}
+		return;
+	}
+
+// generate char events if we want text input without popping up an on-screen keyboard
+// when a physical one isn't present, e.g. when using a searchable menu on the Steam Deck.
+// Note: shift modifier is currently not supported for emulated char events.
+	if (down && !keydown[K_SHIFT] && IN_EmulatedCharEvents ())
+		Char_Event (keycode);
+
+// handle escape specialy, so the user can never unbind it
+	if (key == K_ESCAPE)
+	{
+		if (!down)
+			return;
+
+		if (keydown[K_SHIFT])
+		{
+			Con_ToggleConsole_f();
+			return;
+		}
+
+		switch (key_dest)
+		{
+		case key_message:
+			Key_Message (key);
+			break;
+		case key_menu:
+			M_Keydown (key);
+			break;
+		case key_game:
+		case key_console:
+			M_ToggleMenu_f ();
+			break;
+		default:
+			Sys_Error ("Bad key_dest");
+		}
+
+		return;
+	}
+
+// if Print Screen isn't bound, take a screenshot
+	if (key == K_PRINTSCREEN && !keybindings[key])
+	{
+		if (down && !wasdown)
+			Cbuf_AddText ("screenshot\n");
+		return;
+	}
+
+// demo controls
+	if (cls.demoplayback && key_dest == key_game)
+	{
+		switch (key)
+		{
+		case K_SPACE:
+		case K_YBUTTON:
+			// Pause
+			if (down > wasdown)
+				cls.demopaused = !cls.demopaused;
+			return;
+
+		case K_UPARROW:
+		case K_DPAD_UP:
+			// Resume/increase speed
+			if (down > wasdown)
+			{
+				if (!cls.demopaused)
+					cls.basedemospeed = CLAMP (0.25f, cls.basedemospeed * 2.f, 8.f);
+				cls.demopaused = false;
+			}
+			return;
+
+		case K_DOWNARROW:
+		case K_DPAD_DOWN:
+			// Decrease speed/pause
+			if (down > wasdown)
+			{
+				cls.basedemospeed *= 0.5f;
+				if (cls.basedemospeed < 0.25f)
+				{
+					cls.basedemospeed = 0.25f;
+					cls.demopaused = true;
+				}
+			}
+			return;
+
+		case K_LEFTARROW:
+		case K_RIGHTARROW:
+		case K_DPAD_LEFT:
+		case K_DPAD_RIGHT:
+		case K_SHIFT:
+		case K_CTRL:
+			// Temporary modifiers: they don't perform their actions on up/down events, but are queried per frame instead
+			// to avoid having to manage state transitions (e.g. pressing esc while still holding left arrow to rewind).
+			return;
+
+		default:
+			// Not a demo control key
+			break;
+		}
+	}
+
+// key up events only generate commands if the game key binding is
+// a button command (leading + sign).  These will occur even in console mode,
+// to keep the character from continuing an action started before a console
+// switch.  Button commands include the kenum as a parameter, so multiple
+// downs can be matched with ups
+	if (!down)
+	{
+		kb = keybindings[key];
+		if (kb && kb[0] == '+')
+		{
+			q_snprintf (cmd, sizeof (cmd), "-%s %i\n", kb+1, key);
+			Cbuf_AddText (cmd);
+		}
+		return;
+	}
+
+// during demo playback, most keys bring up the main menu
+	if (cls.demoplayback && down && consolekeys[key] && key_dest == key_game && key != K_TAB)
+	{
+		M_ToggleMenu_f ();
+		return;
+	}
+
+// if not a consolekey, send to the interpreter no matter what mode is
+	if ((key_dest == key_menu && menubound[key] && !M_WaitingForKeyBinding ()) ||
+	    (key_dest == key_console && !consolekeys[key]) ||
+	    (key_dest == key_game && (!con_forcedup || !consolekeys[key])))
+	{
+		kb = keybindings[key];
+		if (kb)
+		{
+			if (kb[0] == '+')
+			{	// button commands add keynum as a parm
+				q_snprintf (cmd, sizeof (cmd), "%s %i\n", kb, key);
+				Cbuf_AddText (cmd);
+			}
+			else
+			{
+				Cbuf_AddText (kb);
+				Cbuf_AddText ("\n");
+			}
+		}
+		return;
+	}
+
+	if (!down)
+		return;		// other systems only care about key down events
+
+	switch (key_dest)
+	{
+	case key_message:
+		Key_Message (key);
+		break;
+	case key_menu:
+		M_Keydown (key);
+		break;
+
+	case key_game:
+	case key_console:
+		Key_Console (key);
+		break;
+	default:
+		Sys_Error ("Bad key_dest");
+	}
+}
+
+/*
+===================
+Char_Event
+
+Called by the backend when the user has input a character.
+===================
+*/
+void Char_Event (int key)
+{
+	if (key < 32 || key > 126)
+		return;
+
+#if defined(PLATFORM_OSX) || defined(PLATFORM_MAC)
+	if (keydown[K_COMMAND])
+		return;
+#endif
+	if (keydown[K_CTRL])
+		return;
+
+	if (key_inputgrab.active)
+	{
+		key_inputgrab.lastchar = key;
+		return;
+	}
+
+	switch (key_dest)
+	{
+	case key_message:
+		Char_Message (key);
+		break;
+	case key_menu:
+		M_Charinput (key);
+		break;
+	case key_game:
+		if (!con_forcedup)
+			break;
+		/* fallthrough */
+	case key_console:
+		Char_Console (key);
+		break;
+	default:
+		break;
+	}
+}
+
+/*
+===================
+Key_TextEntry
+===================
+*/
+textmode_t Key_TextEntry (void)
+{
+	if (key_inputgrab.active)
+	{
+		// This path is used for simple single-letter inputs (y/n prompts) that also
+		// accept controller input, so we don't want an onscreen keyboard for this case.
+		return TEXTMODE_NOPOPUP;
+	}
+
+	switch (key_dest)
+	{
+	case key_message:
+		return TEXTMODE_ON;
+	case key_menu:
+		return M_TextEntry();
+	case key_game:
+		// Don't return true even during con_forcedup, because that happens while starting a
+		// game and we don't to trigger text input (and the onscreen keyboard on some devices)
+		// during this.
+		return TEXTMODE_OFF;
+	case key_console:
+		return TEXTMODE_ON;
+	default:
+		return TEXTMODE_OFF;
+	}
+}
+
+/*
+===================
+Key_ClearStates
+===================
+*/
+void Key_ClearStates (void)
+{
+	int	i;
+
+	for (i = 0; i < MAX_KEYS; i++)
+	{
+		if (keydown[i])
+			Key_Event (i, false);
+	}
+}
+
+/*
+===================
+Key_UpdateForDest
+===================
+*/
+void Key_UpdateForDest (void)
+{
+	static qboolean forced = false;
+
+	if (cls.state == ca_dedicated)
+		return;
+
+	switch (key_dest)
+	{
+	case key_console:
+		if (forced && cls.state == ca_connected)
+		{
+			forced = false;
+			IN_Activate();
+			key_dest = key_game;
+		}
+		break;
+	case key_game:
+		if (cls.state != ca_connected)
+		{
+			forced = true;
+			IN_DeactivateForConsole();
+			key_dest = key_console;
+			break;
+		}
+	/* fallthrough */
+	default:
+		forced = false;
+		break;
+	}
+}
+

--- a/Quake/keys.h
+++ b/Quake/keys.h
@@ -1,0 +1,227 @@
+/*
+Copyright (C) 1996-2001 Id Software, Inc.
+Copyright (C) 2002-2009 John Fitzgibbons and others
+Copyright (C) 2010-2014 QuakeSpasm developers
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+*/
+
+#ifndef _QUAKE_KEYS_H
+#define _QUAKE_KEYS_H
+
+//
+// gamepad button definitions
+//
+#define GAMEPAD_KEY_LIST(def)																					\
+	/*	Keycode			Enum value			XBox name			PlayStation name			Nintendo name	*/	\
+	def (K_START,		= K_GAMEPAD_BEGIN,	"MENU",				"OPTIONS",					"+")				\
+	def (K_BACK,		/*auto*/,			"VIEW",				"CREATE",					"-")				\
+	def (K_GUIDE,		/*auto*/,			NULL,				"PS",						"HOME")			  	\
+	def (K_LTHUMB,		/*auto*/,			"LS",				"L3",						"LSB")				\
+	def (K_RTHUMB,		/*auto*/,			"RS",				"R3",						"RSB")				\
+	def (K_LSHOULDER,	/*auto*/,			"LB",				"L1",						"L")				\
+	def (K_RSHOULDER,	/*auto*/,			"RB",				"R1",						"R")				\
+	def (K_DPAD_UP,		/*auto*/,			"DPAD UP",			"DPAD UP",					"DPAD UP")			\
+	def (K_DPAD_DOWN,	/*auto*/,			"DPAD DOWN",		"DPAD DOWN",				"DPAD DOWN")		\
+	def (K_DPAD_LEFT,	/*auto*/,			"DPAD LEFT",		"DPAD LEFT",				"DPAD LEFT")		\
+	def (K_DPAD_RIGHT,	/*auto*/,			"DPAD RIGHT",		"DPAD RIGHT",				"DPAD RIGHT")		\
+	def (K_ABUTTON,		/*auto*/,			"A",				"X",						"A")				\
+	def (K_BBUTTON,		/*auto*/,			"B",				"CIRCLE",					"B")				\
+	def (K_XBUTTON,		/*auto*/,			"X",				"SQUARE",					"X")				\
+	def (K_YBUTTON,		/*auto*/,			"Y",				"TRIANGLE",					"Y")				\
+	def (K_LTRIGGER,	/*auto*/,			"LT",				"L2",						"ZL")				\
+	def (K_RTRIGGER,	/*auto*/,			"RT",				"R2",						"ZR")				\
+	def (K_MISC1,		/*auto*/,			NULL,				"MUTE",						"CAPTURE")			\
+	def (K_PADDLE1,		/*auto*/,			"P1 PADDLE",		NULL,						NULL)				\
+	def (K_PADDLE2,		/*auto*/,			"P2 PADDLE",		NULL,						NULL)				\
+	def (K_PADDLE3,		/*auto*/,			"P3 PADDLE",		NULL,						NULL)				\
+	def (K_PADDLE4,		/*auto*/,			"P4 PADDLE",		NULL,						NULL)				\
+	def (K_TOUCHPAD,	/*auto*/,			NULL,				"TOUCHPAD",					NULL)				\
+
+
+//
+// these are the key numbers that should be passed to Key_Event
+//
+typedef enum keycode_t
+{
+	K_TAB				= 9,
+	K_ENTER				= 13,
+	K_ESCAPE			= 27,
+	K_SPACE				= 32,
+
+// normal keys should be passed as lowercased ascii
+
+	K_BACKSPACE			= 127,
+	K_UPARROW,
+	K_DOWNARROW,
+	K_LEFTARROW,
+	K_RIGHTARROW,
+
+	K_ALT,
+	K_CTRL,
+	K_SHIFT,
+	K_F1,
+	K_F2,
+	K_F3,
+	K_F4,
+	K_F5,
+	K_F6,
+	K_F7,
+	K_F8,
+	K_F9,
+	K_F10,
+	K_F11,
+	K_F12,
+	K_INS,
+	K_DEL,
+	K_PGDN,
+	K_PGUP,
+	K_HOME,
+	K_END,
+
+	K_KP_NUMLOCK,
+	K_KP_SLASH,
+	K_KP_STAR,
+	K_KP_MINUS,
+	K_KP_HOME,
+	K_KP_UPARROW,
+	K_KP_PGUP,
+	K_KP_PLUS,
+	K_KP_LEFTARROW,
+	K_KP_5,
+	K_KP_RIGHTARROW,
+	K_KP_END,
+	K_KP_DOWNARROW,
+	K_KP_PGDN,
+	K_KP_ENTER,
+	K_KP_INS,
+	K_KP_DEL,
+
+	K_COMMAND,
+
+	K_CAPSLOCK,
+	K_SCROLLLOCK,
+	K_PRINTSCREEN,
+
+//
+// mouse buttons generate virtual keys
+//
+	K_MOUSE_BEGIN		= 200,
+	K_MOUSE1			= K_MOUSE_BEGIN,
+	K_MOUSE2,
+	K_MOUSE3,
+
+// thumb buttons
+	K_MOUSE4,
+	K_MOUSE5,
+
+// JACK: Intellimouse(c) Mouse Wheel Support
+	K_MWHEELUP,
+	K_MWHEELDOWN,
+
+	K_MOUSE_END,
+
+// SDL2 game controller keys
+// Note: start/back are never actually generated, they are always remapped to ESC/TAB
+// The values below are only present to make it easier to name these keys in the menus
+	K_GAMEPAD_BEGIN = K_MOUSE_END,
+	#define GAMEPAD_KEYCODE_ENUM(keycode, value, xboxname, psname, nintendoname) keycode value,
+	GAMEPAD_KEY_LIST (GAMEPAD_KEYCODE_ENUM)
+	#undef GAMEPAD_KEYCODE_ENUM
+	K_GAMEPAD_END,
+	K_GAMEPAD_COUNT = K_GAMEPAD_END - K_GAMEPAD_BEGIN,
+
+	K_PAUSE = K_GAMEPAD_END,
+
+	NUM_KEYCODES,
+} keycode_t;
+
+#define	MAX_KEYS		256
+COMPILE_TIME_ASSERT (too_many_keycodes, NUM_KEYCODES <= MAX_KEYS);
+
+#define	MAXCMDLINE	256
+
+typedef enum {key_game, key_console, key_message, key_menu} keydest_t;
+typedef enum textmode_t
+{
+	TEXTMODE_OFF,		// no char events
+	TEXTMODE_ON,		// char events, show on-screen keyboard
+	TEXTMODE_NOPOPUP,	// char events, don't show on-screen keyboard
+} textmode_t;
+
+typedef enum keydevice_t
+{
+	KD_NONE = -1,
+	KD_KEYBOARD,
+	KD_MOUSE,
+	KD_GAMEPAD,
+} keydevice_t;
+
+typedef enum
+{
+	KDM_NONE				= 0,
+	KDM_KEYBOARD			= 1 << KD_KEYBOARD,
+	KDM_MOUSE				= 1 << KD_MOUSE,
+	KDM_GAMEPAD				= 1 << KD_GAMEPAD,
+	KDM_KEYBOARD_AND_MOUSE	= KDM_KEYBOARD | KDM_MOUSE,
+	KDM_ANY					= -1,
+} keydevicemask_t;
+
+extern keydest_t	key_dest;
+extern	char	*keybindings[MAX_KEYS];
+
+#define		CMDLINES 64
+
+extern	char	key_lines[CMDLINES][MAXCMDLINE];
+extern	char	key_tabhint[MAXCMDLINE];
+extern	int		edit_line;
+extern	int		key_linepos;
+extern	int		key_insert;
+extern	double		key_blinktime;
+
+extern	qboolean	chat_team;
+
+void Key_Init (void);
+void Key_ClearStates (void);
+void Key_UpdateForDest (void);
+
+void Key_BeginInputGrab (void);
+void Key_EndInputGrab (void);
+void Key_GetGrabbedInput (int *lastkey, int *lastchar);
+
+void Key_Event (int key, qboolean down);
+void Key_EventWithKeycode (int key, qboolean down, int keycode);
+void Char_Event (int key);
+textmode_t Key_TextEntry (void);
+
+void Key_SetBinding (int keynum, const char *binding);
+keydevice_t Key_GetDeviceForKeynum (int keynum);
+keydevicemask_t Key_GetDeviceMaskForKeynum (int keynum);
+int Key_GetKeysForCommand (const char *command, int *keys, int maxkeys, keydevicemask_t devmask);
+const char *Key_KeynumToString (int keynum);
+const char *Key_KeynumToFriendlyString (int keynum);
+void Key_WriteBindings (FILE *f);
+
+void Key_EndChat (void);
+const char *Key_GetChatBuffer (void);
+int Key_GetChatMsgLen (void);
+
+void History_Init (void);
+void History_Shutdown (void);
+
+#endif	/* _QUAKE_KEYS_H */
+


### PR DESCRIPTION
This adds a mapping for the guide button (e.g. Xbox/PS/Home) on gamepads.

I've tested on both an Xbox One and Switch Pro controller and it's working fine. I don't currently have any Playstation controllers to test with, but it should work.