### PR TITLE
gl_fog: fix NaN fog density from float/double precision mismatch in fade_done

### DIFF
--- a/Quake/gl_fog.c
+++ b/Quake/gl_fog.c
@@ -43,7 +43,7 @@ static float old_green;
 static float old_blue;
 
 static float fade_time; //duration of fade
-static float fade_done; //time when fade will be done
+static double fade_done; //time when fade will be done
 
 extern float skyfog;
 


### PR DESCRIPTION
Edit: simplified the hell out of the comment.


Problem:
When mods trigger instant fog changes, a rounding error between variable types makes the engine think a fade is happening. This causes a math error (divide-by-zero) that corrupts the fog rendering for one frame, resulting in a visible flash. In mods that update fog frequently, like Arcane Dimensions, this causes constant flickering  _**in demo playback**_

Fix:
Change fade_done from float to double in gl_fog.c to prevent the rounding error.

static double fade_done; 

Alternative Approach:
could instead add a check to stop the divide-by-zero directly. I chose to fix the rounding error at its source, but have no preference against the other method if that fits the project better.