### PR TITLE
Add "match rank" to move exact matches to top of list

### DIFF
--- a/Quake/console.c
+++ b/Quake/console.c
@@ -1550,6 +1550,7 @@ typedef struct tab_s
 	struct tab_s	*next;
 	struct tab_s	*prev;
 	int			count;
+	int			rank;
 } tab_t;
 tab_t	*tablist;
 
@@ -1563,6 +1564,28 @@ typedef struct cmdalias_s
 	char	*value;
 } cmdalias_t;
 extern	cmdalias_t	*cmd_alias;
+
+int Con_CompareTabEntry (int rank, const char* name, const tab_t* t)
+{
+	if (rank != t->rank) {
+		return rank - t->rank;
+	}
+	return q_strnaturalcmp (name, t->name);
+}
+
+int Con_MatchRank (const char *name, const char *partial)
+{
+	if (q_strcasestr (name, partial) != name) {
+		return 2; // partial not at start of string
+	}
+	else if (name[strlen(partial)])
+	{
+		return 1; // partial prefixes whole string
+	}
+	else {
+		return 0; // partial matches string exactly
+	}
+}
 
 /*
 ============
@@ -1582,10 +1605,12 @@ void Con_AddToTabList (const char *name, const char *partial, const char *type)
 	tab_t	*t,*insert;
 	char	*i_bash, *i_bash2;
 	const char *i_name, *i_name2;
-	int		namelen, typelen, mark;
+	int		namelen, typelen, mark, rank;
 
 	if (!Con_Match (name, partial))
 		return;
+
+	rank = Con_MatchRank (name, partial);
 
 	if (!*bash_partial && bash_singlematch)
 	{
@@ -1633,6 +1658,7 @@ void Con_AddToTabList (const char *name, const char *partial, const char *type)
 		memcpy ((char *) t->type, type, typelen);
 	}
 	t->count = 1;
+	t->rank = rank;
 
 	if (!tablist) //create list
 	{
@@ -1640,7 +1666,7 @@ void Con_AddToTabList (const char *name, const char *partial, const char *type)
 		t->next = t;
 		t->prev = t;
 	}
-	else if (q_strnaturalcmp (name, tablist->name) < 0) //insert at front
+	else if (Con_CompareTabEntry(rank, name, tablist) < 0) //insert at front
 	{
 		t->next = tablist;
 		t->prev = tablist->prev;
@@ -1653,7 +1679,7 @@ void Con_AddToTabList (const char *name, const char *partial, const char *type)
 		insert = tablist;
 		do
 		{
-			int cmp = q_strnaturalcmp (name, insert->name);
+			int cmp = Con_CompareTabEntry (rank, name, insert);
 			if (!cmp && !strcmp (name, insert->name)) // avoid duplicates
 			{
 				Hunk_FreeToLowMark (mark);

--- a/Quake/console.c
+++ b/Quake/console.c
@@ -1543,6 +1543,12 @@ void Con_LogCenterPrint (const char *str)
 //johnfitz -- tab completion stuff
 //unique defs
 char key_tabpartial[MAXCMDLINE];
+enum ConsoleMatchRank
+{
+	EXACT,
+	PREFIX,
+	INTERNAL
+};
 typedef struct tab_s
 {
 	const char	*name;
@@ -1550,7 +1556,7 @@ typedef struct tab_s
 	struct tab_s	*next;
 	struct tab_s	*prev;
 	int			count;
-	int			rank;
+	enum ConsoleMatchRank	rank;
 } tab_t;
 tab_t	*tablist;
 
@@ -1565,7 +1571,7 @@ typedef struct cmdalias_s
 } cmdalias_t;
 extern	cmdalias_t	*cmd_alias;
 
-int Con_CompareTabEntry (int rank, const char* name, const tab_t* t)
+int Con_CompareTabEntry (enum ConsoleMatchRank rank, const char* name, const tab_t* t)
 {
 	if (rank != t->rank) {
 		return rank - t->rank;
@@ -1576,14 +1582,14 @@ int Con_CompareTabEntry (int rank, const char* name, const tab_t* t)
 int Con_MatchRank (const char *name, const char *partial)
 {
 	if (q_strcasestr (name, partial) != name) {
-		return 2; // partial not at start of string
+		return INTERNAL; // partial not at start of string
 	}
 	else if (name[strlen(partial)])
 	{
-		return 1; // partial prefixes whole string
+		return PREFIX; // partial prefixes whole string
 	}
 	else {
-		return 0; // partial matches string exactly
+		return EXACT; // partial matches string exactly
 	}
 }
 
@@ -1605,7 +1611,8 @@ void Con_AddToTabList (const char *name, const char *partial, const char *type)
 	tab_t	*t,*insert;
 	char	*i_bash, *i_bash2;
 	const char *i_name, *i_name2;
-	int		namelen, typelen, mark, rank;
+	int		namelen, typelen, mark;
+	enum ConsoleMatchRank rank;
 
 	if (!Con_Match (name, partial))
 		return;


### PR DESCRIPTION
Adds a "rank" variable to the tab-completion sort, allowing exact matches to bubble up to the top rather than be buried. Typing `not` `tab` will select notarget _first_ then tabbing will continue through the cvars that contain `not`.

Addresses #435. 

Tested, here's an image of a recent action build vs mine:
<img width="1909" height="459" alt="Screenshot 2026-07-13 125156" src="https://github.com/user-attachments/assets/84545882-bb48-451d-864f-c2b6ea2da492" />
