### PR TITLE
Allow versioned ent files from earlier dirs

### DIFF
--- a/Quake/gl_model.c
+++ b/Quake/gl_model.c
@@ -992,23 +992,24 @@ static void Mod_LoadEntities (lump_t *l)
 		q_snprintf(entfilename, sizeof(entfilename), "%s.ent", basemapname);
 		Con_DPrintf2("trying to load %s\n", entfilename);
 		ents = (char *) COM_LoadHunkFile (entfilename, &path_id);
+		if (ents)
+		{
+			// use ent file only from the same gamedir as the map
+			// itself or from a searchpath with higher priority.
+			if (path_id < loadmodel->path_id)
+			{
+				ents = NULL;
+				Hunk_FreeToLowMark (mark);
+				Con_DPrintf ("ignored %s from a gamedir with lower priority\n", entfilename);
+			}
+		}
 	}
 
 	if (ents)
 	{
-		// use ent file only from the same gamedir as the map
-		// itself or from a searchpath with higher priority.
-		if (path_id < loadmodel->path_id)
-		{
-			Hunk_FreeToLowMark(mark);
-			Con_DPrintf("ignored %s from a gamedir with lower priority\n", entfilename);
-		}
-		else
-		{
-			loadmodel->entities = ents;
-			Con_DPrintf("Loaded external entity file %s\n", entfilename);
-			return;
-		}
+		loadmodel->entities = ents;
+		Con_DPrintf("Loaded external entity file %s\n", entfilename);
+		return;
 	}
 
 _load_embedded:


### PR DESCRIPTION
Using `game gameplaymod mapset` will let you play a mapset that doesn't include its own progs under a gameplay mod, loading it the other way would load gameplaymod's start.bsp.  

With this patch, gameplay mods can include crc versioned .ent files that enhance other maps loaded later in the path.

This is a niche usecase, but since the .ent files are versioned anyways there's little risk to allowing this to function. 