### PR TITLE
Add -nosteamwarn to skip Steam not running dialog

### DIFF
--- a/Quake/steam.c
+++ b/Quake/steam.c
@@ -504,21 +504,25 @@ qboolean Steam_Init (const steamgame_t *game)
 	{
 		Sys_Printf ("Steam not running\n");
 
-		SDL_ShowSimpleMessageBox (
-			SDL_MESSAGEBOX_INFORMATION,
-			"Steam not running",
-			"Steam must be running in order to update achievements,\n"
-			"track total time played, and show in-game status to your friends.\n"
-			"\n"
-			"If this functionality is important to you, please start Steam\n"
-			"before continuing.\n",
-			NULL
-		);
+		// -nosteamwarn: skip the blocking dialog; Steam API init still attempted below
+		if (!COM_CheckParm ("-nosteamwarn"))
+		{
+			SDL_ShowSimpleMessageBox (
+				SDL_MESSAGEBOX_INFORMATION,
+				"Steam not running",
+				"Steam must be running in order to update achievements,\n"
+				"track total time played, and show in-game status to your friends.\n"
+				"\n"
+				"If this functionality is important to you, please start Steam\n"
+				"before continuing.\n",
+				NULL
+			);
 
-		if (SteamAPI_IsSteamRunning_Func ())
-			Sys_Printf ("Steam is now running, continuing\n");
-		else
-			Sys_Printf ("Steam is still not running\n");
+			if (SteamAPI_IsSteamRunning_Func ())
+				Sys_Printf ("Steam is now running, continuing\n");
+			else
+				Sys_Printf ("Steam is still not running\n");
+		}
 	}
 
 	if (!SteamAPI_Init_Func ())


### PR DESCRIPTION
## Summary
- Adds optional `-nosteamwarn` that skips the blocking Steam-not-running SDL dialog
- Does not disable Steam API (use `-nosteamapi` for that); features still work when Steam is running
- Useful when launching without the Steam client (e.g. game streaming) while keeping Steam-detected game data

## Test plan
- [x] Steam running: no dialog, API still initializes
- [x] Steam closed, no flag: dialog still appears
- [x] Steam closed + `-nosteamwarn`: no dialog; game starts
- [x] `-nosteamapi` still disables Steam API entirely