### PR TITLE
Refactor/modernize SteamAPI to restore  Steam bindings on Linux

### DIFF
--- a/Quake/steam.c
+++ b/Quake/steam.c
@@ -37,27 +37,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	#define STEAMAPI
 #endif
 
-#define STEAMAPI_FUNCTIONS(x)\
-	x(int,		SteamAPI_IsSteamRunning, (void))\
-	x(int,		SteamAPI_Init, (void))\
-	x(void,		SteamAPI_Shutdown, (void))\
-	x(int,		SteamAPI_GetHSteamUser, (void))\
-	x(int,		SteamAPI_GetHSteamPipe, (void))\
-	x(void*,	SteamInternal_CreateInterface, (const char *which))\
-	x(void*,	SteamAPI_ISteamClient_GetISteamFriends, (void *client, int huser, int hpipe, const char *version))\
-	x(void*,	SteamAPI_ISteamClient_GetISteamUserStats, (void *client, int huser, int hpipe, const char *version))\
-	x(void*,	SteamAPI_ISteamClient_GetISteamScreenshots, (void *client, int huser, int hpipe, const char *version))\
-	x(void,		SteamAPI_ISteamFriends_ClearRichPresence, (void *client))\
-	x(int,		SteamAPI_ISteamFriends_SetRichPresence, (void *friends, const char *key, const char *val))\
-	x(int,		SteamAPI_ISteamUserStats_SetAchievement, (void *userstats, const char *name))\
-	x(int,		SteamAPI_ISteamUserStats_StoreStats, (void *userstats))\
-	x(int,		SteamAPI_ISteamScreenshots_HookScreenshots, (void *screenshots, int hook))\
-	x(uint32_t,	SteamAPI_ISteamScreenshots_WriteScreenshot, (void *screenshots, const void *data, uint32_t size, int width, int height))\
-
-#define STEAMAPI_CLIENT_VERSION							"SteamClient015"
-#define STEAMAPI_FRIENDS_VERSION						"SteamFriends015"
-#define STEAMAPI_USERSTATS_VERSION						"STEAMUSERSTATS_INTERFACE_VERSION012"
-#define STEAMAPI_SCREENSHOTS_VERSION					"STEAMSCREENSHOTS_INTERFACE_VERSION003"
+#define STEAMAPI_FUNCTIONS(x) \
+	x(int,      SteamAPI_IsSteamRunning,                    (void)) \
+	x(int,      SteamAPI_InitFlat,                          (void *pOutErrMsg)) \
+	x(void,     SteamAPI_Shutdown,                          (void)) \
+	x(void *,   SteamAPI_SteamFriends_v018,                 (void)) \
+	x(void *,   SteamAPI_SteamUserStats_v013,               (void)) \
+	x(void *,   SteamAPI_SteamScreenshots_v003,             (void)) \
+	x(void,     SteamAPI_ISteamFriends_ClearRichPresence,   (void *friends)) \
+	x(int,      SteamAPI_ISteamFriends_SetRichPresence,     (void *friends, const char *key, const char *value)) \
+	x(int,      SteamAPI_ISteamUserStats_SetAchievement,    (void *userstats, const char *name)) \
+	x(int,      SteamAPI_ISteamUserStats_StoreStats,        (void *userstats)) \
+	x(int,      SteamAPI_ISteamScreenshots_HookScreenshots, (void *screenshots, int hook)) \
+	x(uint32_t, SteamAPI_ISteamScreenshots_WriteScreenshot, (void *screenshots, const void *data, uint32_t size, int width, int height))
 
 #define STEAMAPI_DECLARE_FUNCTION(ret, name, args)		static ret (STEAMAPI *name##_Func) args;
 STEAMAPI_FUNCTIONS (STEAMAPI_DECLARE_FUNCTION)
@@ -79,9 +71,6 @@ static const apifunc_t steamapi_funcs[] =
 static struct
 {
 	void			*library;
-	int				hsteamuser;
-	int				hsteampipe;
-	void			*client;
 	void			*friends;
 	void			*userstats;
 	void			*screenshots;
@@ -464,7 +453,6 @@ static qboolean Steam_LoadLibrary (const steamgame_t *game)
 	return steamapi.library != NULL;
 }
 
-
 /*
 ========================
 Steam_Init
@@ -492,6 +480,7 @@ qboolean Steam_Init (const steamgame_t *game)
 		Sys_Printf ("Couldn't load Steam API library\n");
 		return false;
 	}
+
 	Sys_Printf ("Loaded Steam API library\n");
 
 	if (!Steam_InitFunctions ())
@@ -511,55 +500,53 @@ qboolean Steam_Init (const steamgame_t *game)
 			"track total time played, and show in-game status to your friends.\n"
 			"\n"
 			"If this functionality is important to you, please start Steam\n"
-			"before continuing.\n",
+			"before closing this dialog box.\n",
 			NULL
 		);
 
 		if (SteamAPI_IsSteamRunning_Func ())
 			Sys_Printf ("Steam is now running, continuing\n");
 		else
+		{
 			Sys_Printf ("Steam is still not running\n");
+			Steam_Shutdown ();
+			return false;
+		}
 	}
 
-	if (!SteamAPI_Init_Func ())
+	if (SteamAPI_InitFlat_Func(NULL) != 0)
 	{
-		Sys_Printf ("Couldn't initialize Steam API\n");
-		Steam_Shutdown ();
+		Sys_Printf("Couldn't initialize Steam API\n");
+		Steam_Shutdown();
 		return false;
 	}
+
 	steamapi.needs_shutdown = true;
 
-	steamapi.hsteamuser		= SteamAPI_GetHSteamUser_Func ();
-	steamapi.hsteampipe		= SteamAPI_GetHSteamPipe_Func ();
-	steamapi.client			= SteamInternal_CreateInterface_Func (STEAMAPI_CLIENT_VERSION);
-	if (!steamapi.client)
-	{
-		Sys_Printf ("ERROR: Couldn't create Steam client interface\n");
-		Steam_Shutdown ();
-		return false;
-	}
+	steamapi.friends = SteamAPI_SteamFriends_v018_Func();
+	steamapi.userstats = SteamAPI_SteamUserStats_v013_Func();
+	steamapi.screenshots = SteamAPI_SteamScreenshots_v003_Func();
 
-	steamapi.friends = SteamAPI_ISteamClient_GetISteamFriends_Func (steamapi.client, steamapi.hsteamuser, steamapi.hsteampipe, STEAMAPI_FRIENDS_VERSION);
 	if (!steamapi.friends)
 	{
-		Sys_Printf ("Couldn't initialize SteamFriends interface\n");
-		Steam_Shutdown ();
+		Sys_Printf("Couldn't obtain SteamFriends interface\n");
+		Steam_Shutdown();
 		return false;
 	}
 
-	steamapi.userstats = SteamAPI_ISteamClient_GetISteamUserStats_Func (steamapi.client, steamapi.hsteamuser, steamapi.hsteampipe, STEAMAPI_USERSTATS_VERSION);
 	if (!steamapi.userstats)
 	{
-		Sys_Printf ("Couldn't initialize SteamUserStats interface\n");
-		Steam_Shutdown ();
+		Sys_Printf("Couldn't obtain SteamUserStats interface\n");
+		Steam_Shutdown();
 		return false;
 	}
 
-	steamapi.screenshots = SteamAPI_ISteamClient_GetISteamScreenshots_Func (steamapi.client, steamapi.hsteamuser, steamapi.hsteampipe, STEAMAPI_SCREENSHOTS_VERSION);
 	if (!steamapi.screenshots)
-		Sys_Printf ("Couldn't initialize SteamScreenshots interface\n");
-	else
-		SteamAPI_ISteamScreenshots_HookScreenshots_Func (steamapi.screenshots, true);
+	{
+		Sys_Printf("Couldn't obtain SteamScreenshots interface\n");
+		Steam_Shutdown();
+		return false;
+	}
 
 	Sys_Printf ("Steam API initialized\n");
 

--- a/Quake/steam.c
+++ b/Quake/steam.c
@@ -71,6 +71,11 @@ STEAMAPI_LEGACY_FUNCTIONS(STEAMAPI_DECLARE_FUNCTION)
 
 #undef STEAMAPI_DECLARE_FUNCTION
 
+#define STEAMAPI_LEGACY_CLIENT_VERSION		"SteamClient015"
+#define STEAMAPI_LEGACY_FRIENDS_VERSION		"SteamFriends017"
+#define STEAMAPI_LEGACY_USERSTATS_VERSION	"STEAMUSERSTATS_INTERFACE_VERSION012"
+#define STEAMAPI_LEGACY_SCREENSHOTS_VERSION	"STEAMSCREENSHOTS_INTERFACE_VERSION003"
+
 typedef struct
 {
 	void		**address;
@@ -561,7 +566,7 @@ static qboolean Steam_LocalInitLegacy (void)
     hsteamuser = SteamAPI_GetHSteamUser_Func ();
     hsteampipe = SteamAPI_GetHSteamPipe_Func ();
 
-    steamapi.client = SteamInternal_CreateInterface_Func ("SteamClient015");
+    steamapi.client = SteamInternal_CreateInterface_Func (STEAMAPI_LEGACY_CLIENT_VERSION);
 
     if (!steamapi.client)
     {
@@ -574,21 +579,21 @@ static qboolean Steam_LocalInitLegacy (void)
             steamapi.client,
             hsteamuser,
             hsteampipe,
-            "SteamFriends017");
+            STEAMAPI_LEGACY_FRIENDS_VERSION);
 
     steamapi.userstats =
         SteamAPI_ISteamClient_GetISteamUserStats_Func (
             steamapi.client,
             hsteamuser,
             hsteampipe,
-            "STEAMUSERSTATS_INTERFACE_VERSION012");
+            STEAMAPI_LEGACY_USERSTATS_VERSION);
 
     steamapi.screenshots =
         SteamAPI_ISteamClient_GetISteamScreenshots_Func (
             steamapi.client,
             hsteamuser,
             hsteampipe,
-            "STEAMSCREENSHOTS_INTERFACE_VERSION003");
+            STEAMAPI_LEGACY_SCREENSHOTS_VERSION);
 
     if (!steamapi.friends ||
         !steamapi.userstats ||

--- a/Quake/steam.c
+++ b/Quake/steam.c
@@ -37,22 +37,38 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	#define STEAMAPI
 #endif
 
-#define STEAMAPI_FUNCTIONS(x) \
-	x(int,      SteamAPI_IsSteamRunning,                    (void)) \
-	x(int,      SteamAPI_InitFlat,                          (void *pOutErrMsg)) \
-	x(void,     SteamAPI_Shutdown,                          (void)) \
-	x(void *,   SteamAPI_SteamFriends_v018,                 (void)) \
-	x(void *,   SteamAPI_SteamUserStats_v013,               (void)) \
-	x(void *,   SteamAPI_SteamScreenshots_v003,             (void)) \
-	x(void,     SteamAPI_ISteamFriends_ClearRichPresence,   (void *friends)) \
-	x(int,      SteamAPI_ISteamFriends_SetRichPresence,     (void *friends, const char *key, const char *value)) \
-	x(int,      SteamAPI_ISteamUserStats_SetAchievement,    (void *userstats, const char *name)) \
-	x(int,      SteamAPI_ISteamUserStats_StoreStats,        (void *userstats)) \
-	x(int,      SteamAPI_ISteamScreenshots_HookScreenshots, (void *screenshots, int hook)) \
-	x(uint32_t, SteamAPI_ISteamScreenshots_WriteScreenshot, (void *screenshots, const void *data, uint32_t size, int width, int height))
+#define STEAMAPI_COMMON_FUNCTIONS(x) \
+    x(int,      SteamAPI_IsSteamRunning,                    (void)) \
+    x(void,     SteamAPI_Shutdown,                          (void)) \
+    x(void,     SteamAPI_ISteamFriends_ClearRichPresence,   (void *friends)) \
+    x(int,      SteamAPI_ISteamFriends_SetRichPresence,     (void *friends, const char *key, const char *value)) \
+    x(int,      SteamAPI_ISteamUserStats_SetAchievement,    (void *userstats, const char *name)) \
+    x(int,      SteamAPI_ISteamUserStats_StoreStats,        (void *userstats)) \
+    x(int,      SteamAPI_ISteamScreenshots_HookScreenshots, (void *screenshots, int hook)) \
+    x(uint32_t, SteamAPI_ISteamScreenshots_WriteScreenshot, (void *screenshots, const void *data, uint32_t size, int width, int height))
 
-#define STEAMAPI_DECLARE_FUNCTION(ret, name, args)		static ret (STEAMAPI *name##_Func) args;
-STEAMAPI_FUNCTIONS (STEAMAPI_DECLARE_FUNCTION)
+#define STEAMAPI_MODERN_FUNCTIONS(x) \
+    x(int,      SteamAPI_InitFlat,                          (char *pOutErrMsg)) \
+    x(void *,   SteamAPI_SteamFriends_v018,                 (void)) \
+    x(void *,   SteamAPI_SteamUserStats_v013,               (void)) \
+    x(void *,   SteamAPI_SteamScreenshots_v003,             (void))
+
+#define STEAMAPI_LEGACY_FUNCTIONS(x) \
+    x(int,      SteamAPI_Init,                              (void)) \
+    x(int,      SteamAPI_GetHSteamUser,                    	(void)) \
+    x(int,      SteamAPI_GetHSteamPipe,                    	(void)) \
+    x(void*,	SteamInternal_CreateInterface, 				(const char *which))\
+    x(void *,   SteamAPI_ISteamClient_GetISteamFriends,     (void *client, int huser, int hpipe, const char *version)) \
+    x(void *,   SteamAPI_ISteamClient_GetISteamUserStats,   (void *client, int huser, int hpipe, const char *version)) \
+    x(void *,   SteamAPI_ISteamClient_GetISteamScreenshots,	(void *client, int huser, int hpipe, const char *version))
+
+#define STEAMAPI_DECLARE_FUNCTION(ret, name, args) \
+    static ret (STEAMAPI *name##_Func) args;
+
+STEAMAPI_COMMON_FUNCTIONS(STEAMAPI_DECLARE_FUNCTION)
+STEAMAPI_MODERN_FUNCTIONS(STEAMAPI_DECLARE_FUNCTION)
+STEAMAPI_LEGACY_FUNCTIONS(STEAMAPI_DECLARE_FUNCTION)
+
 #undef STEAMAPI_DECLARE_FUNCTION
 
 typedef struct
@@ -61,16 +77,34 @@ typedef struct
 	const char	*name;
 } apifunc_t;
 
-static const apifunc_t steamapi_funcs[] =
+static const apifunc_t steamapi_common_funcs[] =
 {
-	#define STEAMAPI_FUNC_DEF(ret, name, args)	{ (void**) &name##_Func, #name },
-	STEAMAPI_FUNCTIONS (STEAMAPI_FUNC_DEF)
-	#undef STEAMAPI_FUNC_DEF
+#define STEAMAPI_FUNC_DEF(ret, name, args) \
+    { (void **) &name##_Func, #name },
+    STEAMAPI_COMMON_FUNCTIONS(STEAMAPI_FUNC_DEF)
+#undef STEAMAPI_FUNC_DEF
+};
+
+static const apifunc_t steamapi_modern_funcs[] =
+{
+#define STEAMAPI_FUNC_DEF(ret, name, args) \
+    { (void **) &name##_Func, #name },
+    STEAMAPI_MODERN_FUNCTIONS(STEAMAPI_FUNC_DEF)
+#undef STEAMAPI_FUNC_DEF
+};
+
+static const apifunc_t steamapi_legacy_funcs[] =
+{
+#define STEAMAPI_FUNC_DEF(ret, name, args) \
+    { (void **) &name##_Func, #name },
+    STEAMAPI_LEGACY_FUNCTIONS(STEAMAPI_FUNC_DEF)
+#undef STEAMAPI_FUNC_DEF
 };
 
 static struct
 {
 	void			*library;
+	void			*client;
 	void			*friends;
 	void			*userstats;
 	void			*screenshots;
@@ -403,11 +437,12 @@ done_cfg:
 Steam_ClearFunctions
 ========================
 */
-static void Steam_ClearFunctions (void)
+static void Steam_ClearFunctions (const apifunc_t *funcs, size_t count)
 {
-	size_t i;
-	for (i = 0; i < Q_COUNTOF (steamapi_funcs); i++)
-		*steamapi_funcs[i].address = NULL;
+    size_t i;
+
+    for (i = 0; i < count; i++)
+        *funcs[i].address = NULL;
 }
 
 /*
@@ -415,28 +450,30 @@ static void Steam_ClearFunctions (void)
 Steam_InitFunctions
 ========================
 */
-static qboolean Steam_InitFunctions (void)
+static qboolean Steam_InitFunctions (const apifunc_t *funcs, size_t count)
 {
-	size_t i, missing;
+    size_t i, missing;
 
-	for (i = missing = 0; i < Q_COUNTOF (steamapi_funcs); i++)
-	{
-		const apifunc_t *func = &steamapi_funcs[i];
-		*func->address = Sys_GetLibraryFunction (steamapi.library, func->name);
-		if (!*func->address)
-		{
-			Sys_Printf ("ERROR: missing Steam API function \"%s\"\n", func->name);
-			missing++;
-		}
-	}
+    for (i = missing = 0; i < count; i++)
+    {
+        const apifunc_t *func = &funcs[i];
 
-	if (missing)
-	{
-		Steam_ClearFunctions ();
-		return false;
-	}
+        *func->address = Sys_GetLibraryFunction (steamapi.library, func->name);
 
-	return true;
+        if (!*func->address)
+        {
+            Sys_Printf ("ERROR: missing Steam API function \"%s\"\n", func->name);
+            missing++;
+        }
+    }
+
+    if (missing)
+    {
+        Steam_ClearFunctions (funcs, count);
+        return false;
+    }
+
+    return true;
 }
 
 /*
@@ -455,9 +492,126 @@ static qboolean Steam_LoadLibrary (const steamgame_t *game)
 
 /*
 ========================
+Steam_LocalInitModern
+========================
+*/
+static qboolean Steam_LocalInitModern (void)
+{
+	qboolean ret = false;
+
+	if (SteamAPI_InitFlat_Func(NULL) != 0)
+	{
+		Sys_Printf("Couldn't initialize Steam API\n");
+		return false;
+	}
+
+	steamapi.needs_shutdown = true;
+
+	steamapi.friends = SteamAPI_SteamFriends_v018_Func();
+	steamapi.userstats = SteamAPI_SteamUserStats_v013_Func();
+	steamapi.screenshots = SteamAPI_SteamScreenshots_v003_Func();
+
+	if (!steamapi.friends)
+	{
+		Sys_Printf("Couldn't obtain SteamFriends interface\n");
+		return false;
+	}
+
+	if (!steamapi.userstats)
+	{
+		Sys_Printf("Couldn't obtain SteamUserStats interface\n");
+		return false;
+	}
+
+	if (!steamapi.screenshots)
+	{
+		Sys_Printf("Couldn't obtain SteamScreenshots interface\n");
+		return false;
+	}
+
+	Sys_Printf ("Steam API initialized\n");
+
+	Steam_ClearStatus ();
+
+	return true;
+}
+
+/*
+========================
+Steam_InitLegacy
+========================
+*/
+static qboolean Steam_LocalInitLegacy (void)
+{
+    int hsteamuser;
+    int hsteampipe;
+
+    if (!Steam_InitFunctions (steamapi_legacy_funcs,
+                               Q_COUNTOF (steamapi_legacy_funcs)))
+        return false;
+
+    if (!SteamAPI_Init_Func ())
+    {
+        Sys_Printf ("Couldn't initialize Steam API\n");
+        return false;
+    }
+
+    steamapi.needs_shutdown = true;
+
+    hsteamuser = SteamAPI_GetHSteamUser_Func ();
+    hsteampipe = SteamAPI_GetHSteamPipe_Func ();
+
+    steamapi.client = SteamInternal_CreateInterface_Func ("SteamClient015");
+
+    if (!steamapi.client)
+    {
+        Sys_Printf ("Couldn't create Steam client interface\n");
+        return false;
+    }
+
+    steamapi.friends =
+        SteamAPI_ISteamClient_GetISteamFriends_Func (
+            steamapi.client,
+            hsteamuser,
+            hsteampipe,
+            "SteamFriends017");
+
+    steamapi.userstats =
+        SteamAPI_ISteamClient_GetISteamUserStats_Func (
+            steamapi.client,
+            hsteamuser,
+            hsteampipe,
+            "STEAMUSERSTATS_INTERFACE_VERSION012");
+
+    steamapi.screenshots =
+        SteamAPI_ISteamClient_GetISteamScreenshots_Func (
+            steamapi.client,
+            hsteamuser,
+            hsteampipe,
+            "STEAMSCREENSHOTS_INTERFACE_VERSION003");
+
+    if (!steamapi.friends ||
+        !steamapi.userstats ||
+        !steamapi.screenshots)
+    {
+        Sys_Printf ("Couldn't obtain Steam interfaces\n");
+        SteamAPI_Shutdown_Func ();
+        steamapi.needs_shutdown = false;
+        Steam_ClearFunctions (steamapi_legacy_funcs,
+                              Q_COUNTOF (steamapi_legacy_funcs));
+        memset (&steamapi, 0, sizeof (steamapi));
+        return false;
+    }
+
+    return true;
+}
+
+/*
+========================
 Steam_Init
 ========================
 */
+
 qboolean Steam_Init (const steamgame_t *game)
 {
 	if (COM_CheckParm ("-nosteamapi"))
@@ -483,7 +637,8 @@ qboolean Steam_Init (const steamgame_t *game)
 
 	Sys_Printf ("Loaded Steam API library\n");
 
-	if (!Steam_InitFunctions ())
+	if (!Steam_InitFunctions (steamapi_common_funcs,
+                     Q_COUNTOF (steamapi_common_funcs)))
 	{
 		Steam_Shutdown ();
 		return false;
@@ -514,45 +669,22 @@ qboolean Steam_Init (const steamgame_t *game)
 		}
 	}
 
-	if (SteamAPI_InitFlat_Func(NULL) != 0)
+	qboolean success = false;
+
+	if (Steam_InitFunctions(steamapi_modern_funcs, Q_COUNTOF(steamapi_modern_funcs)))
+		success = Steam_LocalInitModern();
+	else
 	{
-		Sys_Printf("Couldn't initialize Steam API\n");
-		Steam_Shutdown();
-		return false;
+		Steam_ClearFunctions(steamapi_modern_funcs, Q_COUNTOF(steamapi_modern_funcs));
+		success = Steam_LocalInitLegacy(); // for Steamworks DLL shipped with rerelease
 	}
 
-	steamapi.needs_shutdown = true;
-
-	steamapi.friends = SteamAPI_SteamFriends_v018_Func();
-	steamapi.userstats = SteamAPI_SteamUserStats_v013_Func();
-	steamapi.screenshots = SteamAPI_SteamScreenshots_v003_Func();
-
-	if (!steamapi.friends)
+	if (!success)
 	{
-		Sys_Printf("Couldn't obtain SteamFriends interface\n");
 		Steam_Shutdown();
-		return false;
 	}
 
-	if (!steamapi.userstats)
-	{
-		Sys_Printf("Couldn't obtain SteamUserStats interface\n");
-		Steam_Shutdown();
-		return false;
-	}
-
-	if (!steamapi.screenshots)
-	{
-		Sys_Printf("Couldn't obtain SteamScreenshots interface\n");
-		Steam_Shutdown();
-		return false;
-	}
-
-	Sys_Printf ("Steam API initialized\n");
-
-	Steam_ClearStatus ();
-
-	return true;
+	return success;
 }
 
 /*
@@ -566,7 +698,14 @@ void Steam_Shutdown (void)
 		return;
 	if (steamapi.needs_shutdown)
 		SteamAPI_Shutdown_Func ();
-	Steam_ClearFunctions ();
+
+	Steam_ClearFunctions (steamapi_common_funcs,
+                              Q_COUNTOF (steamapi_common_funcs));
+	Steam_ClearFunctions (steamapi_modern_funcs,
+                              Q_COUNTOF (steamapi_modern_funcs));
+	Steam_ClearFunctions (steamapi_legacy_funcs,
+                              Q_COUNTOF (steamapi_legacy_funcs));
+
 	Sys_CloseLibrary (steamapi.library);
 	memset (&steamapi, 0, sizeof (steamapi));
 	Sys_Printf ("Unloaded Steam API\n");

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "arch_def.h"
 #include "quakedef.h"
 #include "steam.h"
+#include "sys.h"
 
 #include <sys/types.h>
 #include <errno.h>
@@ -31,6 +32,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <string.h>
 #if defined(PLATFORM_OSX) || defined(PLATFORM_HAIKU)
 #include <libgen.h>	/* dirname() and basename() */
+#endif
+#if defined(PLATFORM_UNIX)
+#include <elf.h>
 #endif
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -59,6 +63,12 @@ static qboolean		stdinIsATTY;	/* from ioquake3 source */
 
 static double rcp_counter_freq;
 
+#ifdef __LP64__
+#define WANTED_ELFCLASS ELFCLASS64
+#else
+#define WANTED_ELFCLASS ELFCLASS32
+#endif
+
 static int findhandle (void)
 {
 	int i;
@@ -70,6 +80,30 @@ static int findhandle (void)
 	}
 	Sys_Error ("out of handles");
 	return -1;
+}
+
+static qboolean Sys_IsELFClass(const char *path, int elfclass)
+{
+	unsigned char ident[EI_NIDENT];
+	FILE *f;
+
+	f = fopen(path, "rb");
+	if (!f)
+		return false;
+
+	if (fread(ident, 1, EI_NIDENT, f) != EI_NIDENT)
+	{
+		fclose(f);
+		return false;
+	}
+
+	fclose(f);
+
+	return ident[EI_MAG0] == ELFMAG0 &&
+		   ident[EI_MAG1] == ELFMAG1 &&
+		   ident[EI_MAG2] == ELFMAG2 &&
+		   ident[EI_MAG3] == ELFMAG3 &&
+		   ident[EI_CLASS] == elfclass;
 }
 
 FILE *Sys_fopen (const char *path, const char *mode)
@@ -347,49 +381,29 @@ qboolean Sys_GetSteamQuakeUserDir (char *path, size_t pathsize, const char *libr
 
 qboolean Sys_GetSteamAPILibraryPath (char *path, size_t pathsize, const steamgame_t *game)
 {
-	char		config_info_path[MAX_OSPATH];
-	char		*line = NULL;
-	size_t		line_size = 0;
-	ssize_t		bytes_read = 0;
-	FILE		*config_info;
-	int			read_lines;
-	qboolean	result;
+	char candidate[MAX_OSPATH];
 
-	if ((size_t) q_snprintf (config_info_path, sizeof (config_info_path), "%s/steamapps/compatdata/%d/config_info", game->library, game->appid) >= pathsize)
-		return false;
-
-	config_info = Sys_fopen (config_info_path, "r");
-	if (!config_info)
-		return false;
-
-	// lib dir is on line 3, lib64 on line 4
-	read_lines = sizeof (void *) == 4 ? 3 : 4;
-	while (read_lines-- > 0)
+	if (Sys_GetSteamDir(candidate, sizeof(candidate)))
 	{
-		if ((bytes_read = getline (&line, &line_size, config_info)) == -1)
+#ifdef __LP64__
+		const char *rel = "steamrt64/libsteam_api.so";
+#else
+		const char *rel = "steamrt32/libsteam_api.so";
+#endif
+
+		if ((size_t)q_snprintf(
+				path,
+				pathsize,
+				"%s/%s",
+				candidate,
+				rel) < pathsize &&
+			Sys_FileType(path) == FS_ENT_FILE)
 		{
-			fclose (config_info);
-			free (line);
-			return false;
+			return true;
 		}
 	}
 
-	fclose (config_info);
-	if (!line)
-		return false;
-
-	line_size = strlen (line);
-
-	if (line_size > 0 && line[line_size - 1] == '\n')
-		line[--line_size] = '\0';
-	if (line_size > 0 && line[line_size - 1] == '/')
-		line[--line_size] = '\0';
-
-	result = (size_t) q_snprintf (path, pathsize, "%s/libsteam_api.so", line) < pathsize;
-
-	free (line);
-
-	return result;
+	return false;
 }
 
 qboolean Sys_GetGOGQuakeDir (char *path, size_t pathsize)

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -63,12 +63,6 @@ static qboolean		stdinIsATTY;	/* from ioquake3 source */
 
 static double rcp_counter_freq;
 
-#ifdef __LP64__
-#define WANTED_ELFCLASS ELFCLASS64
-#else
-#define WANTED_ELFCLASS ELFCLASS32
-#endif
-
 static int findhandle (void)
 {
 	int i;
@@ -80,30 +74,6 @@ static int findhandle (void)
 	}
 	Sys_Error ("out of handles");
 	return -1;
-}
-
-static qboolean Sys_IsELFClass(const char *path, int elfclass)
-{
-	unsigned char ident[EI_NIDENT];
-	FILE *f;
-
-	f = fopen(path, "rb");
-	if (!f)
-		return false;
-
-	if (fread(ident, 1, EI_NIDENT, f) != EI_NIDENT)
-	{
-		fclose(f);
-		return false;
-	}
-
-	fclose(f);
-
-	return ident[EI_MAG0] == ELFMAG0 &&
-		   ident[EI_MAG1] == ELFMAG1 &&
-		   ident[EI_MAG2] == ELFMAG2 &&
-		   ident[EI_MAG3] == ELFMAG3 &&
-		   ident[EI_CLASS] == elfclass;
 }
 
 FILE *Sys_fopen (const char *path, const char *mode)

--- a/Quake/sys_sdl_unix.c
+++ b/Quake/sys_sdl_unix.c
@@ -33,9 +33,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #if defined(PLATFORM_OSX) || defined(PLATFORM_HAIKU)
 #include <libgen.h>	/* dirname() and basename() */
 #endif
-#if defined(PLATFORM_UNIX)
-#include <elf.h>
-#endif
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <fcntl.h>


### PR DESCRIPTION
On Linux, Ironwail currently reads the `config_info` from Proton's compatdata for the title and expects the Linux runtime on line 3 (x86) or line 4 (x64) of the file. Newer Proton versions don't follow this format, breaking the detection mechanism. This PR ensures the use of the `libsteam_api.so` runtime from the main Steam runtime directory instead of scanning for the directory from the `config_info` file.

Additionally, modern Steamworks SDK deprecates and removes the `SteamAPI_Init()` + obtaining interfaces through `SteamClient` in favour of a newer flat API with `SteamApi_InitFlat()`. The modern function names have been taken from the exported symbols, these will probably change in the future requiring a patch. Might be a better solution, scanning the exports on start or something?

To fix this for Proton and also keep compatibility with the bundled `steam_api.dll` from the 2021 rerelease itself I split the `STEAMAPI_FUNCTIONS` x-macro table into 'common', 'modern' and 'legacy'.

Verified working on both Linux (CachyOS) and Windows 11. And all this because I just wanted to earn some achievements :D

Related issue: #436.